### PR TITLE
disable_full_ci_on_doc_change

### DIFF
--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -6,10 +6,15 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+    - 'docs/**' # Ignores changes within the 'docs' directory
+    - '**/*.md'  # Ignores changes to any markdown files
   pull_request:
     branches:
       - main
-
+    paths-ignore:
+      - 'docs/**' # Ignores changes within the 'docs' directory
+      - '**/*.md'  # Ignores changes to any markdown files
 jobs:
   run-linters:
     timeout-minutes: 5


### PR DESCRIPTION
- Change github workflow settings so that we do not need to run the full workflow if only docs change.