### PR TITLE
Generate API Documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,10 +2,34 @@ site_name: ME/CFS Biostatistics Home
 site_url: https://sitename.example
 theme:
   name: material
+  features:
+    - navigation.indexes
 
-markdown_extensions:
-  - pymdownx.arithmatex:
-      generic: true
+
+plugins:
+- search
+- mkdocstrings:
+   handlers:
+      python:
+        inventories:
+          - https://docs.python.org/3/objects.inv
+        options:
+          paths: [.]
+          docstring_section_style: list # or "table"
+          docstring_style: "numpy"
+          filters: [ "!^_" ]
+          heading_level: 1
+          merge_init_into_class: true
+          parameter_headings: true
+          separate_signature: true
+          show_root_heading: true
+          show_signature_annotations: true
+          show_symbol_type_heading: true
+          show_symbol_type_toc: true
+          summary: true
+- api-autonav:
+    modules: ['src_new']
+    exclude: ['src_new.assets','src_new.analysis','src_new.util']
 
 extra_javascript:
   - javascripts/mathjax.js

--- a/pixi.lock
+++ b/pixi.lock
@@ -109,6 +109,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/mergedeep-1.3.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-1.6.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-get-deps-0.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-literate-nav-0.6.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-material-9.6.23-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-material-extensions-1.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
@@ -195,6 +196,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/3b/a5/7279055cf004561894ed3a7bfdf5bf90a53f28fadd01af7cd166e88ddf16/google_crc32c-1.7.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/82/35/b8d3baf8c46695858cb9d8835a53baa1eeb9906ddaf2f728a5f5b640fd1e/google_resumable_media-2.7.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/25/e8/eba9fece11d57a71e3e22ea672742c8f3cf23b35730c9e96db768b295216/googleapis_common_protos-1.71.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9c/83/3b1d03d36f224edded98e9affd0467630fc09d766c0e56fb1498cbb04a9b/griffe-1.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f5/bb/f97d06b60f32e30b7ba25336f0886c24b13855d7ca8642200e4d70382a45/gtfparse-1.3.0.tar.gz
       - pypi: https://files.pythonhosted.org/packages/25/2e/dc2ecbfa9c988e90549abbdca451a021a2aba7a369d2704ea0cc80f277be/gwaslab-3.6.8-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3a/30/d1c94066343a98bb2cea40120873193a4fed68c4ad7f8935c11caf74c681/h5py-3.15.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
@@ -215,6 +217,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/70/db/23f8b5d86c9385299586c2469b58087f658f58eaeb414be0fd64cfd054e1/memoized-property-1.0.3.tar.gz
       - pypi: https://files.pythonhosted.org/packages/df/21/01431251720764246970a0bb9359fd8734007b518773a5102b089c46aec2/mkdocs-plotly-plugin-0.1.3.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/f0/37/e1413281aec69994a0ecb8baaff523b7b7da3119ae7d495b7dc659e630b0/mkdocs_api_autonav-0.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9f/4d/7123b6fa2278000688ebd338e2a06d16870aaf9eceae6ba047ea05f92df1/mkdocs_autorefs-1.4.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e7/0f/1e55b3fd490ad2cecb6e7b31892d27cb9fc4218ec1dab780440ba8579e74/mkdocs_gen_files-0.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7b/2c/f0dc4e1ee7f618f5bff7e05898d20bf8b6e7fa612038f768bfa295f136a4/mkdocstrings-0.30.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/98/5c/2597cef67b6947b15c47f8dba967a0baf19fbdfdc86f6e4a8ba7af8b581a/mkdocstrings_python-1.19.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/d9/617e6af809bf3a1d468e0d58c3997b1dc219a9a9202e650d30c2fc85d481/mock-5.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0d/e2/9baffdae21a76f77ef8447f1a05a96ec4bc0a24dae08767abc0a2fe680b8/multidict-6.7.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/77/ae/6c3d2c7c61ff21f2bee938c917616c92ebf852f015fb55917fd6e2811db2/mypy-1.18.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -698,7 +705,7 @@ packages:
 - pypi: ./
   name: biostatistics
   version: 0.1.0
-  sha256: f8cd05e5a7bbd194357d9cb46302b9bef8b76ad87bd7a53cf25364f5369b7d62
+  sha256: ea0c4771df5d2799a245703bba6b10f4015713da1cf8e63e3b291693f0851482
   requires_dist:
   - attrs>=25.3.0
   - cattrs>=25.2.0
@@ -735,6 +742,10 @@ packages:
   - scikit-learn>=1.7.2,<2
   - mkdocs-plotly-plugin>=0.1.3,<0.2
   - gdown>=5.2.0,<6
+  - mkdocs-gen-files>=0.5.0,<0.6
+  - mkdocs-literate-nav
+  - mkdocs-api-autonav>=0.4.0,<0.5
+  - mkdocstrings[python]>=0.30.1,<0.31
   requires_python: ==3.12
   editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py312h67db365_0.conda
@@ -1377,6 +1388,16 @@ packages:
   - protobuf>=3.20.2,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<7.0.0
   - grpcio>=1.44.0,<2.0.0 ; extra == 'grpc'
   requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/9c/83/3b1d03d36f224edded98e9affd0467630fc09d766c0e56fb1498cbb04a9b/griffe-1.15.0-py3-none-any.whl
+  name: griffe
+  version: 1.15.0
+  sha256: 6f6762661949411031f5fcda9593f586e6ce8340f0ba88921a0f2ef7a81eb9a3
+  requires_dist:
+  - colorama>=0.4
+  - pip>=24.0 ; extra == 'pypi'
+  - platformdirs>=4.2 ; extra == 'pypi'
+  - wheel>=0.42 ; extra == 'pypi'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/f5/bb/f97d06b60f32e30b7ba25336f0886c24b13855d7ca8642200e4d70382a45/gtfparse-1.3.0.tar.gz
   name: gtfparse
   version: 1.3.0
@@ -2586,6 +2607,31 @@ packages:
   - pkg:pypi/mkdocs?source=hash-mapping
   size: 3524754
   timestamp: 1734344673481
+- pypi: https://files.pythonhosted.org/packages/f0/37/e1413281aec69994a0ecb8baaff523b7b7da3119ae7d495b7dc659e630b0/mkdocs_api_autonav-0.4.0-py3-none-any.whl
+  name: mkdocs-api-autonav
+  version: 0.4.0
+  sha256: 87474e7919664fca75648a05e79de238dd5b39a0f711910d3638626b016acfe3
+  requires_dist:
+  - mkdocs>=1.6
+  - mkdocstrings-python>=1.11.0
+  - pyyaml>=5
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/9f/4d/7123b6fa2278000688ebd338e2a06d16870aaf9eceae6ba047ea05f92df1/mkdocs_autorefs-1.4.3-py3-none-any.whl
+  name: mkdocs-autorefs
+  version: 1.4.3
+  sha256: 469d85eb3114801d08e9cc55d102b3ba65917a869b893403b8987b601cf55dc9
+  requires_dist:
+  - markdown>=3.3
+  - markupsafe>=2.0.1
+  - mkdocs>=1.1
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/e7/0f/1e55b3fd490ad2cecb6e7b31892d27cb9fc4218ec1dab780440ba8579e74/mkdocs_gen_files-0.5.0-py3-none-any.whl
+  name: mkdocs-gen-files
+  version: 0.5.0
+  sha256: 7ac060096f3f40bd19039e7277dd3050be9a453c8ac578645844d4d91d7978ea
+  requires_dist:
+  - mkdocs>=1.0.3
+  requires_python: '>=3.7'
 - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-get-deps-0.2.0-pyhd8ed1ab_1.conda
   sha256: e0b501b96f7e393757fb2a61d042015966f6c5e9ac825925e43f9a6eafa907b6
   md5: 84382acddb26c27c70f2de8d4c830830
@@ -2601,6 +2647,18 @@ packages:
   - pkg:pypi/mkdocs-get-deps?source=hash-mapping
   size: 14757
   timestamp: 1734353035244
+- conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-literate-nav-0.6.2-pyhd8ed1ab_0.conda
+  sha256: ff9ee7059a1ca1ca8480c827fa2de432049a40910193cbe3956a83bac2f5f7af
+  md5: cf98ee24777947d5934e225aecccebbc
+  depends:
+  - mkdocs >=1.4.1
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/mkdocs-literate-nav?source=hash-mapping
+  size: 18602
+  timestamp: 1742369304752
 - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-material-9.6.23-pyhcf101f3_0.conda
   sha256: 86f84db5f028ba882546b56815fc62e03fa947e04f4933fa181d9bb29445d15e
   md5: b00890e53c4c652f55f3afc4290a814a
@@ -2647,6 +2705,32 @@ packages:
   - beautifulsoup4>=4.11.1
   - flatten-dict>=0.4.2
   requires_python: '>=3.6'
+- pypi: https://files.pythonhosted.org/packages/7b/2c/f0dc4e1ee7f618f5bff7e05898d20bf8b6e7fa612038f768bfa295f136a4/mkdocstrings-0.30.1-py3-none-any.whl
+  name: mkdocstrings
+  version: 0.30.1
+  sha256: 41bd71f284ca4d44a668816193e4025c950b002252081e387433656ae9a70a82
+  requires_dist:
+  - jinja2>=2.11.1
+  - markdown>=3.6
+  - markupsafe>=1.1
+  - mkdocs>=1.6
+  - mkdocs-autorefs>=1.4
+  - pymdown-extensions>=6.3
+  - importlib-metadata>=4.6 ; python_full_version < '3.10'
+  - mkdocstrings-crystal>=0.3.4 ; extra == 'crystal'
+  - mkdocstrings-python-legacy>=0.2.1 ; extra == 'python-legacy'
+  - mkdocstrings-python>=1.16.2 ; extra == 'python'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/98/5c/2597cef67b6947b15c47f8dba967a0baf19fbdfdc86f6e4a8ba7af8b581a/mkdocstrings_python-1.19.0-py3-none-any.whl
+  name: mkdocstrings-python
+  version: 1.19.0
+  sha256: 395c1032af8f005234170575cc0c5d4d20980846623b623b35594281be4a3059
+  requires_dist:
+  - mkdocstrings>=0.30
+  - mkdocs-autorefs>=1.4
+  - griffe>=1.13
+  - typing-extensions>=4.0 ; python_full_version < '3.11'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/bd/d9/617e6af809bf3a1d468e0d58c3997b1dc219a9a9202e650d30c2fc85d481/mock-5.2.0-py3-none-any.whl
   name: mock
   version: 5.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "types-tqdm>=4.67.0.20250809",
     "universal-pathlib>=0.3.4",
     "xarray>=2025.9.1",
-    "xxhash>=3.6.0", "ibis-framework[duckdb,examples]>=11.0.0,<12", "scikit-learn>=1.7.2,<2", "mkdocs-plotly-plugin>=0.1.3,<0.2", "gdown>=5.2.0,<6",
+    "xxhash>=3.6.0", "ibis-framework[duckdb,examples]>=11.0.0,<12", "scikit-learn>=1.7.2,<2", "mkdocs-plotly-plugin>=0.1.3,<0.2", "gdown>=5.2.0,<6", "mkdocs-gen-files>=0.5.0,<0.6", "mkdocs-literate-nav", "mkdocs-api-autonav>=0.4.0,<0.5", "mkdocstrings[python]>=0.30.1,<0.31",
 ]
 
 [tool.pixi.workspace]
@@ -61,3 +61,4 @@ pyarrow = ">=22.0.0,<23"
 rust = ">=1.90.0,<1.91"
 duckdb = ">=1.4.1,<2"
 mkdocs-material = ">=9.6.23,<10"
+mkdocs-literate-nav = "*"

--- a/src_new/__init__.py
+++ b/src_new/__init__.py
@@ -1,0 +1,3 @@
+"""
+Root directory for refactored code, that makes use of the new incremental build system.
+"""

--- a/src_new/assets/gwas/inflammatory_bowel_disease/liu_et_al_2023/raw_gwas_data/liu_et_al_2023_meta.py
+++ b/src_new/assets/gwas/inflammatory_bowel_disease/liu_et_al_2023/raw_gwas_data/liu_et_al_2023_meta.py
@@ -1,5 +1,3 @@
-import polars as pl
-
 """
 GWAS summary statistics from the 2023 meta-analysis of Liu et al.
 See: https://www.nature.com/articles/s41588-023-01384-0
@@ -7,6 +5,8 @@ Google Drive link to downloads: https://drive.google.com/drive/folders/1MbjKuYp7
 """
 
 from pathlib import PurePath
+
+import polars as pl
 
 from src_new.build_system.meta.asset_id import AssetId
 from src_new.build_system.meta.gwas_summary_file_meta import GWASSummaryDataFileMeta

--- a/src_new/build_system/__init__.py
+++ b/src_new/build_system/__init__.py
@@ -1,0 +1,3 @@
+"""
+Incremental build system framework. See "Build Systems a la Carte" by Mokhov, Mitchell, and Peyton Jones for a conceptual discussion.
+"""

--- a/src_new/build_system/asset/__init__.py
+++ b/src_new/build_system/asset/__init__.py
@@ -1,0 +1,3 @@
+"""
+An asset is a materialized directory or file that is either of interest in itself, or is an input to downstream Task.
+"""

--- a/src_new/build_system/asset/directory_asset.py
+++ b/src_new/build_system/asset/directory_asset.py
@@ -7,6 +7,10 @@ from src_new.build_system.asset.base_asset import Asset
 
 @frozen
 class DirectoryAsset(Asset):
+    """
+    A materialized directory output of a Task.
+    """
+
     path: Path
 
     def __attrs_post_init__(self):

--- a/src_new/build_system/asset/file_asset.py
+++ b/src_new/build_system/asset/file_asset.py
@@ -7,6 +7,10 @@ from src_new.build_system.asset.base_asset import Asset
 
 @frozen
 class FileAsset(Asset):
+    """
+    A materialized file output of a Task.
+    """
+
     path: Path
 
     def __attrs_post_init__(self):

--- a/src_new/build_system/meta/__init__.py
+++ b/src_new/build_system/meta/__init__.py
@@ -1,0 +1,3 @@
+"""
+Meta objects are uniquely identifying metadata describing either an asset that currently exists, or an asset that can be created by a build system.
+"""

--- a/src_new/build_system/meta/meta.py
+++ b/src_new/build_system/meta/meta.py
@@ -1,3 +1,7 @@
+"""
+Meta objects are uniquely identifying metadata describing either an asset that currently exists, or an asset that can be created by a build system.
+"""
+
 from src_new.build_system.meta.executable.executable_meta import ExecutableMeta
 from src_new.build_system.meta.filtered_gwas_data_meta import FilteredGWASDataMeta
 from src_new.build_system.meta.gwas_summary_file_meta import GWASSummaryDataFileMeta
@@ -26,10 +30,6 @@ from src_new.build_system.meta.reference_meta.reference_file_meta import (
 from src_new.build_system.meta.simple_directory_meta import SimpleDirectoryMeta
 from src_new.build_system.meta.simple_file_meta import SimpleFileMeta
 
-"""
-Meta objects are uniquely identifying metadata describing either an asset that currently exists,
-or an asset that can be created by a build system.
-"""
 Meta = (
     SimpleFileMeta
     | SimpleDirectoryMeta

--- a/src_new/build_system/rebuilder/__init__.py
+++ b/src_new/build_system/rebuilder/__init__.py
@@ -1,0 +1,3 @@
+"""
+A rebuilder performs the following key operations: A) Decide whether a given asset is up-to-date using the info-store. B) If the asset is up-to-date, return it together with the info-store. C) If the asset is not up-to-date, bring it up-to-date, update the info-store, and return the new values of both.
+"""

--- a/src_new/build_system/reference/__init__.py
+++ b/src_new/build_system/reference/__init__.py
@@ -1,0 +1,3 @@
+"""
+Vendored reference data.
+"""

--- a/src_new/build_system/runner/__init__.py
+++ b/src_new/build_system/runner/__init__.py
@@ -1,0 +1,3 @@
+"""
+Runners are convenience objets that bundle a scheduler with a rebuilder to create a complete build system
+"""

--- a/src_new/build_system/scheduler/__init__.py
+++ b/src_new/build_system/scheduler/__init__.py
@@ -1,0 +1,5 @@
+"""
+Given target assets, the scheduler is responsible for traversing the dependency graph consisting of the target assets and their transitive dependencies.
+
+Delegates the actual work of materializing an individual asset up to date to the rebuilder.
+"""

--- a/src_new/build_system/serialization/converter.py
+++ b/src_new/build_system/serialization/converter.py
@@ -1,4 +1,3 @@
 from cattrs import GenConverter
 
 CONVERTER_FOR_SERIALIZATION = GenConverter()
-# configure_tagged_union(Meta, converter=CONVERTER_FOR_SERIALIZATION)

--- a/src_new/build_system/task/__init__.py
+++ b/src_new/build_system/task/__init__.py
@@ -1,0 +1,4 @@
+"""
+Task objects are where the "real work" of the build system is encapsulated.
+A Task encodes instructions for how to materialize a given asset. These instructions may include requesting that the build system materialize any dependencies the asset has.
+"""

--- a/src_new/build_system/tasks/__init__.py
+++ b/src_new/build_system/tasks/__init__.py
@@ -1,0 +1,4 @@
+"""
+A "Tasks" is a collection that maps each asset id to the Task that materializes the corresponding Asset.
+Used by the schedulers in the build system.
+"""

--- a/src_new/build_system/tasks/base_tasks.py
+++ b/src_new/build_system/tasks/base_tasks.py
@@ -7,7 +7,7 @@ from src_new.build_system.task.base_task import Task
 
 class Tasks(ABC, Mapping[AssetId, Task]):
     """
-    Collection associating a piece of asset_id with a task that can produce the corresponding asset.
+    Collection associating an asset_id with a task that can produce the corresponding asset.
     """
 
     @abstractmethod

--- a/src_new/build_system/wf/__init__.py
+++ b/src_new/build_system/wf/__init__.py
@@ -1,0 +1,3 @@
+"""
+A WF (or Workflow) is an interface tasks can use to download files.
+"""

--- a/src_new/build_system/wf/base_wf.py
+++ b/src_new/build_system/wf/base_wf.py
@@ -7,6 +7,8 @@ import py3_wget
 class WF(ABC):
     """
     An interface to the external world.
+    Currently only used for downloading files.
+    May be extended in the future .
     """
 
     def download_from_url(self, url: str, local_path: Path) -> None:


### PR DESCRIPTION
- I used several mkdocs plugins to auto-generate api documentation for the build system.
- I cleaned up and expanded a few docstrings to make this auto-generated api-documentation more readable.
- In the future, we can also auto-generate documentation for key assets.
closes #117 