### PR TITLE
Improve the un-tar Task

### DIFF
--- a/test_mecfs_bio/unit/build_system/task/test_exract_tar_gzip_task.py
+++ b/test_mecfs_bio/unit/build_system/task/test_exract_tar_gzip_task.py
@@ -1,34 +1,56 @@
 import tarfile
 import tempfile
 from pathlib import Path
+from typing import Literal
+
+import pytest
 
 from mecfs_bio.build_system.asset.base_asset import Asset
 from mecfs_bio.build_system.asset.file_asset import FileAsset
 from mecfs_bio.build_system.meta.asset_id import AssetId
 from mecfs_bio.build_system.meta.simple_file_meta import SimpleFileMeta
-from mecfs_bio.build_system.task.extract_tar_gzip_task import ExtractTarGzipTask
+from mecfs_bio.build_system.task.extract_tar_gzip_task import (
+    ExtractTarGzipTask,
+    ReadMode,
+)
 from mecfs_bio.build_system.task.fake_task import FakeTask
 from mecfs_bio.build_system.wf.base_wf import SimpleWF
 
+WriteMode = Literal["w:gz", "w"]
 
-def _create_dummy_tar_file(contents: str, name_in_tar: str, pth: Path) -> None:
+
+def _create_dummy_tar_file(
+    contents: str, name_in_tar: str, pth: Path, mode: WriteMode = "w:gz"
+) -> None:
     with tempfile.TemporaryDirectory() as tmp_dir:
         tmp_path = Path(tmp_dir) / name_in_tar
         tmp_path.write_text(contents)
-        with tarfile.open(pth, mode="w:gz") as tar_object:
+        with tarfile.open(pth, mode=mode) as tar_object:
             tar_object.add(tmp_path, arcname=name_in_tar)
 
 
-def test_extract_tar_gzip_task(tmp_path: Path):
+@pytest.mark.parametrize(
+    ["read_mode", "write_mode"],
+    [
+        ["r:gz", "w:gz"],
+        ["r", "w"],
+    ],
+)
+def test_extract_tar_gzip_task(
+    tmp_path: Path, read_mode: ReadMode, write_mode: WriteMode
+):
     tar_loc = tmp_path / "my_tar.tar.gzip"
     file_contents = "abc123"
     name_in_tar = "my_tarred_file"
-    _create_dummy_tar_file(file_contents, pth=tar_loc, name_in_tar=name_in_tar)
+    _create_dummy_tar_file(
+        file_contents, pth=tar_loc, name_in_tar=name_in_tar, mode=write_mode
+    )
     scratch_dir = tmp_path / "scratch"
     tsk = ExtractTarGzipTask(
         meta=SimpleFileMeta(AssetId("my_file")),
         source_file_task=FakeTask(meta=SimpleFileMeta(AssetId("dummy_file"))),
         subdir_name=None,
+        read_mode=read_mode,
     )
 
     def fetch(asset_id: AssetId) -> Asset:


### PR DESCRIPTION
-  Extend the task for opening tar files to allow it to work on tar files that are not gzipped
- Update test
- This is needed since many S-LDSC reference files are tar archives