### PR TITLE
Add Gene Annotation and FIltering to MAGMA Task Generator

### DIFF
--- a/mecfs_bio/analysis/ldl_analysis.py
+++ b/mecfs_bio/analysis/ldl_analysis.py
@@ -18,6 +18,7 @@ def run_ldl_analysis():
     DEFAULT_RUNNER.run(
         [
             MILLION_VETERANS_EUR_LDL_MAGMA_TASKS.inner.bar_plot_task,
+            MILLION_VETERANS_EUR_LDL_MAGMA_TASKS.inner.labeled_filtered_gene_analysis_task,
             MILLION_VETERAN_LDL_BASE_CELL_ANALYSIS_BY_LDSC,
         ],
         incremental_save=True,

--- a/mecfs_bio/assets/gwas/ldl/million_veterans/processed_gwas_data/million_veterans_ldl_eur_magma_task_generator.py
+++ b/mecfs_bio/assets/gwas/ldl/million_veterans/processed_gwas_data/million_veterans_ldl_eur_magma_task_generator.py
@@ -4,6 +4,9 @@ from mecfs_bio.assets.executable.extracted.magma_binary_extracted import (
 from mecfs_bio.assets.gwas.ldl.million_veterans.raw_gwas_data.raw_ldl_data import (
     MILLION_VETERAN_LDL_EUR_DATA_RAW,
 )
+from mecfs_bio.assets.reference_data.ensembl_biomart.gene_thesaurus import (
+    GENE_THESAURUS,
+)
 from mecfs_bio.assets.reference_data.magma_gene_locations.raw.magma_ensembl_gene_location_reference_data_build_37 import (
     MAGMA_ENSEMBL_GENE_LOCATION_REFERENCE_DATA_BUILD_37_RAW,
 )
@@ -47,4 +50,5 @@ MILLION_VETERANS_EUR_LDL_MAGMA_TASKS = MagmaTaskGeneratorFromRaw.create(
         snpid=None,
     ),
     pre_pipe=FilterRowsByInfoScorePipe(min_score=0.8, info_col="r2"),
+    gene_thesaurus_task=GENE_THESAURUS,
 )

--- a/mecfs_bio/build_system/runner/simple_runner.py
+++ b/mecfs_bio/build_system/runner/simple_runner.py
@@ -2,6 +2,10 @@ from pathlib import Path
 from typing import Mapping, Sequence
 
 import structlog
+from rich.pretty import pprint
+
+from mecfs_bio.build_system.asset.directory_asset import DirectoryAsset
+from mecfs_bio.build_system.asset.file_asset import FileAsset
 
 logger = structlog.get_logger()
 import attrs
@@ -91,4 +95,17 @@ class SimpleRunner:
             incremental_save_path=incremental_save_path,
         )
         info.serialize(self.info_store)
+        _print_target_locs(store, targets=targets)
         return store
+
+
+def _print_target_locs(store: Mapping[AssetId, Asset], targets: list[Task]):
+    logger.info("Locations of materialized targets:\n")
+    target_locs: dict = {}
+    for item in targets:
+        asset = store[item.asset_id]
+        if isinstance(asset, (FileAsset, DirectoryAsset)):
+            target_locs[item.asset_id] = str(asset.path)
+        else:
+            target_locs[item.asset_id] = asset
+    pprint(target_locs)

--- a/mecfs_bio/build_system/task/join_dataframes_task.py
+++ b/mecfs_bio/build_system/task/join_dataframes_task.py
@@ -79,7 +79,7 @@ class JoinDataFramesTask(Task):
             df_2, how=self.how, left_on=list(self.left_on), right_on=list(self.right_on)
         )
         result = joined.collect().to_pandas()
-        logger.debug(f"\nresult of join:\n {result.to_markdown(index=False)}")
+        # logger.debug(f"\nresult of join:\n {result.to_markdown(index=False)}")
         result.to_csv(result_path, index=False)
         return FileAsset(result_path)
 


### PR DESCRIPTION
- Follow up on previous PR.  Add Gene annotation and filtering to MAGMA task generator, so that it is part of the standard MAGMA workflow
- Verify it works by running MAGMA analysis of LDL