### PR TITLE
Add additional reference datasets for SLDSC

### DIFF
--- a/mecfs_bio/assets/reference_data/linkage_disequilibrium_score_reference_data/extracted/partitioned_model_cahoy_ld_scores_extracted.py
+++ b/mecfs_bio/assets/reference_data/linkage_disequilibrium_score_reference_data/extracted/partitioned_model_cahoy_ld_scores_extracted.py
@@ -1,0 +1,12 @@
+from mecfs_bio.assets.reference_data.linkage_disequilibrium_score_reference_data.raw.partitioned_model_cahoy_ld_scores import (
+    PARTITIONED_MODEL_CAHOY_LD_SCORES_RAW,
+)
+from mecfs_bio.build_system.task.extract_tar_gzip_task import ExtractTarGzipTask
+
+PARTITIONED_MODEL_CAHOY_LD_SCORES_EXTRACTED = (
+    ExtractTarGzipTask.create_from_reference_file_task(
+        asset_id="partitioned_model_cahoy_ld_scores_extracted",
+        source_task=PARTITIONED_MODEL_CAHOY_LD_SCORES_RAW,
+        read_mode="r",
+    )
+)

--- a/mecfs_bio/assets/reference_data/linkage_disequilibrium_score_reference_data/extracted/partitioned_model_gtex_brain_ld_scores_extracted.py
+++ b/mecfs_bio/assets/reference_data/linkage_disequilibrium_score_reference_data/extracted/partitioned_model_gtex_brain_ld_scores_extracted.py
@@ -1,0 +1,12 @@
+from mecfs_bio.assets.reference_data.linkage_disequilibrium_score_reference_data.raw.partitioned_model_gtex_brain_ld_scores import (
+    PARTITIONED_MODEL_GTEX_BRAIN_LD_SCORES_RAW,
+)
+from mecfs_bio.build_system.task.extract_tar_gzip_task import ExtractTarGzipTask
+
+PARTITIONED_MODEL_GTEX_BRAIN_LD_SCORES_EXTRACTED = (
+    ExtractTarGzipTask.create_from_reference_file_task(
+        asset_id="partitioned_model_gtex_brain_ld_scores_extracted",
+        source_task=PARTITIONED_MODEL_GTEX_BRAIN_LD_SCORES_RAW,
+        read_mode="r",
+    )
+)

--- a/mecfs_bio/assets/reference_data/linkage_disequilibrium_score_reference_data/extracted/partitioned_model_immgen_ld_scores_extracted.py
+++ b/mecfs_bio/assets/reference_data/linkage_disequilibrium_score_reference_data/extracted/partitioned_model_immgen_ld_scores_extracted.py
@@ -1,0 +1,12 @@
+from mecfs_bio.assets.reference_data.linkage_disequilibrium_score_reference_data.raw.partitioned_model_immgen_ld_scores import (
+    PARTITIONED_MODEL_IMMGEN_LD_SCORES_RAW,
+)
+from mecfs_bio.build_system.task.extract_tar_gzip_task import ExtractTarGzipTask
+
+PARTITIONED_MODEL_IMMGEN_LD_SCORES_EXTRACTED = (
+    ExtractTarGzipTask.create_from_reference_file_task(
+        asset_id="partitioned_model_immgen_ld_scores_extracted",
+        source_task=PARTITIONED_MODEL_IMMGEN_LD_SCORES_RAW,
+        read_mode="r",
+    )
+)

--- a/mecfs_bio/assets/reference_data/linkage_disequilibrium_score_reference_data/extracted/partitioned_model_multi_tissue_chromatin_ld_scores_extracted.py
+++ b/mecfs_bio/assets/reference_data/linkage_disequilibrium_score_reference_data/extracted/partitioned_model_multi_tissue_chromatin_ld_scores_extracted.py
@@ -1,0 +1,12 @@
+from mecfs_bio.assets.reference_data.linkage_disequilibrium_score_reference_data.raw.partitioned_model_multi_tissue_chromatin_ld_scores import (
+    PARTITIONED_MODEL_MULTI_TISSUE_CHROMATIN_LD_SCORES_RAW,
+)
+from mecfs_bio.build_system.task.extract_tar_gzip_task import ExtractTarGzipTask
+
+PARTITIONED_MODEL_MULTI_TISSUE_CHROMATIN_LD_SCORES_EXTRACTED = (
+    ExtractTarGzipTask.create_from_reference_file_task(
+        asset_id="partitioned_model_multi_tissue_chromatin_ld_scores_extracted",
+        source_task=PARTITIONED_MODEL_MULTI_TISSUE_CHROMATIN_LD_SCORES_RAW,
+        read_mode="r",
+    )
+)

--- a/mecfs_bio/assets/reference_data/linkage_disequilibrium_score_reference_data/raw/partitioned_model_cahoy_ld_scores.py
+++ b/mecfs_bio/assets/reference_data/linkage_disequilibrium_score_reference_data/raw/partitioned_model_cahoy_ld_scores.py
@@ -1,0 +1,35 @@
+"""
+This is a dataset of partitioned LD scores associated with brain cell types.
+
+It comes from the  paper
+
+ "Heritability enrichment of specifically expressed genes identifies disease-relevant tissues and cell types." Nature genetics 50.4 (2018): 621-629.
+
+ The data is originally derived from transcriptome data from experiments on mouse brains reported in
+
+Cahoy, John D., et al. "A transcriptome database for astrocytes, neurons, and oligodendrocytes: a new resource for understanding brain development and function." Journal of Neuroscience 28.1 (2008): 264-278.
+
+Data is officially located at : https://console.cloud.google.com/storage/browser/broad-alkesgroup-public-requester-pays
+
+I re-hosted on dropbox.
+"""
+
+from pathlib import PurePath
+
+from mecfs_bio.build_system.meta.reference_meta.reference_file_meta import (
+    ReferenceFileMeta,
+)
+from mecfs_bio.build_system.task.download_file_task import DownloadFileTask
+
+PARTITIONED_MODEL_CAHOY_LD_SCORES_RAW: DownloadFileTask = DownloadFileTask(
+    meta=ReferenceFileMeta(
+        asset_id="cahoy_partitioned_ld_scores",
+        group="linkage_disequilibrium_scores",
+        sub_group="LDSCORE_LDSC_SEG",
+        sub_folder=PurePath("raw"),
+        filename="LDSCORE_LDSC_SEG_ldscores_Cahoy_1000Gv3_ldscores",
+        extension=".tar",
+    ),
+    url="https://www.dropbox.com/scl/fi/jnxzjt6wytng8xtdwkgeb/LDSCORE_LDSC_SEG_ldscores_Cahoy_1000Gv3_ldscores.tar?rlkey=ed12zeugsc6q8ddawcy1cifqm&dl=1",
+    md5_hash="15c5e5e8f056a12f1da65cd5d45b1963",
+)

--- a/mecfs_bio/assets/reference_data/linkage_disequilibrium_score_reference_data/raw/partitioned_model_gtex_brain_ld_scores.py
+++ b/mecfs_bio/assets/reference_data/linkage_disequilibrium_score_reference_data/raw/partitioned_model_gtex_brain_ld_scores.py
@@ -1,0 +1,34 @@
+"""
+Paritioned LD scores associated from brain tissue types.
+
+
+Comes from the paper:
+
+ "Heritability enrichment of specifically expressed genes identifies disease-relevant tissues and cell types." Nature genetics 50.4 (2018): 621-629.
+
+ Originally derived from the GTEx project
+
+Data is officially located at : https://console.cloud.google.com/storage/browser/broad-alkesgroup-public-requester-pays
+
+I re-hosted on dropbox.
+"""
+
+from pathlib import PurePath
+
+from mecfs_bio.build_system.meta.reference_meta.reference_file_meta import (
+    ReferenceFileMeta,
+)
+from mecfs_bio.build_system.task.download_file_task import DownloadFileTask
+
+PARTITIONED_MODEL_GTEX_BRAIN_LD_SCORES_RAW: DownloadFileTask = DownloadFileTask(
+    meta=ReferenceFileMeta(
+        asset_id="gtex_brain_partitioned_ld_scores",
+        group="linkage_disequilibrium_scores",
+        sub_group="LDSCORE_LDSC_SEG",
+        sub_folder=PurePath("raw"),
+        filename="LDSCORE_LDSC_SEG_ldscores_GTEx_brain_1000Gv3_ldscores",
+        extension=".tar",
+    ),
+    url="https://www.dropbox.com/scl/fi/yg0bf3tq077ut74040wed/LDSCORE_LDSC_SEG_ldscores_GTEx_brain_1000Gv3_ldscores.tar?rlkey=dz8me7skwswwfsybytbe4wg8o&dl=1",
+    md5_hash="b9842d0ef3b0b9afe0434d63c43067b2",
+)

--- a/mecfs_bio/assets/reference_data/linkage_disequilibrium_score_reference_data/raw/partitioned_model_immgen_ld_scores.py
+++ b/mecfs_bio/assets/reference_data/linkage_disequilibrium_score_reference_data/raw/partitioned_model_immgen_ld_scores.py
@@ -1,0 +1,36 @@
+"""
+Partitioned LD scores associated from immunological cell types.
+
+
+From the paper:
+
+ "Heritability enrichment of specifically expressed genes identifies disease-relevant tissues and cell types." Nature genetics 50.4 (2018): 621-629.
+
+Data originally derived from:
+
+Heng, Tracy SP, et al. "The Immunological Genome Project: networks of gene expression in immune cells." Nature immunology 9.10 (2008): 1091-1094.
+
+Data is officially located at : https://console.cloud.google.com/storage/browser/broad-alkesgroup-public-requester-pays
+
+I re-hosted on dropbox.
+"""
+
+from pathlib import PurePath
+
+from mecfs_bio.build_system.meta.reference_meta.reference_file_meta import (
+    ReferenceFileMeta,
+)
+from mecfs_bio.build_system.task.download_file_task import DownloadFileTask
+
+PARTITIONED_MODEL_IMMGEN_LD_SCORES_RAW: DownloadFileTask = DownloadFileTask(
+    meta=ReferenceFileMeta(
+        asset_id="immgen_partitioned_ld_scores",
+        group="linkage_disequilibrium_scores",
+        sub_group="LDSCORE_LDSC_SEG",
+        sub_folder=PurePath("raw"),
+        filename="LDSCORE_LDSC_SEG_ldscores_ImmGen_1000Gv3_ldscores",
+        extension=".tar",
+    ),
+    url="https://www.dropbox.com/scl/fi/kb30br7qcc68lsn84zak0/LDSCORE_LDSC_SEG_ldscores_ImmGen_1000Gv3_ldscores.tar?rlkey=rndsvy5q7m14sxp3swgu4r0lt&dl=1",
+    md5_hash="0cddb5ac5348045e4adabe9dac1c9485",
+)

--- a/mecfs_bio/assets/reference_data/linkage_disequilibrium_score_reference_data/raw/partitioned_model_multi_tissue_chromatin_ld_scores.py
+++ b/mecfs_bio/assets/reference_data/linkage_disequilibrium_score_reference_data/raw/partitioned_model_multi_tissue_chromatin_ld_scores.py
@@ -22,4 +22,29 @@ We again computed a P-value to test whether the regression coefficient was posit
 
 Roughly speaking the underlying logic of this dataset is as follows: In certain tissue or cell types, certain regions of the genome are known to be marked by special histone marks in certain
 . These marks indicate that a nearby gene is being transcribed in those tissues or cell types.
+
+
+Data is officially located at : https://console.cloud.google.com/storage/browser/broad-alkesgroup-public-requester-pays
+
+I re-hosted on dropbox.
 """
+
+from pathlib import PurePath
+
+from mecfs_bio.build_system.meta.reference_meta.reference_file_meta import (
+    ReferenceFileMeta,
+)
+from mecfs_bio.build_system.task.download_file_task import DownloadFileTask
+
+PARTITIONED_MODEL_MULTI_TISSUE_CHROMATIN_LD_SCORES_RAW: DownloadFileTask = DownloadFileTask(
+    meta=ReferenceFileMeta(
+        asset_id="multi_tissue_chromatin_partitioned_ld_scores",
+        group="linkage_disequilibrium_scores",
+        sub_group="LDSCORE_LDSC_SEG",
+        sub_folder=PurePath("raw"),
+        filename="LDSCORE_LDSC_SEG_ldscores_Multi_tissue_chromatin_1000Gv3_ldscores",
+        extension=".tar",
+    ),
+    url="https://www.dropbox.com/scl/fi/8gdia1hhbjg65l4lvvpnt/LDSCORE_LDSC_SEG_ldscores_Multi_tissue_chromatin_1000Gv3_ldscores.tar?rlkey=94v5r1mjawbd1ha2gzmrg3bur&dl=1",
+    md5_hash="8aa379558c9ff8986965b4337b5ce6d2",
+)


### PR DESCRIPTION
- Add tasks to get additional reference datasets for SLDSC.  
- These are the datasets described in the wiki entry here: https://github.com/bulik/ldsc/wiki/Cell-type-specific-analyses, and used in the paper:  "Heritability enrichment of specifically expressed genes identifies disease-relevant tissues and cell types." Nature genetics 50.4 (2018): 621-629.

- These datasets describe categorizations of genetic variants according to various functional categories derived from experimental data, as well as ld scores of each genetic variant with each category.

