### PR TITLE
Add categorical labels to Immgen cells

### DIFF
--- a/docs/Analysis/Verma_et_Al_(LDL)/S-LDSC_LDL_Analysis.md
+++ b/docs/Analysis/Verma_et_Al_(LDL)/S-LDSC_LDL_Analysis.md
@@ -78,3 +78,46 @@ Note that the all the histone modifications in the table above are associated wi
 
 Consistent with our findings above, these results point to the liver are a key cite of LDL physiology.  Unlike the GTEx results above, they also implicate adipose tissue as a cite of important physiology.
 
+
+## Immgen data
+
+The next step is to use the SLDSC reference data derived from the Immgen project.  This results in no significant tissue-type hits.  The top non-significant hits are:
+
+| Name                            |   Coefficient |   Coefficient_P_value | Reject Null   |
+|:--------------------------------|--------------:|----------------------:|:--------------|
+| T.4SP69+.Th                     |   2.09672e-08 |            0.00229273 | False         |
+| T.4Nve.Sp                       |   1.61296e-08 |            0.0091171  | False         |
+| Mo.6C-IIint.Bl                  |   1.24572e-08 |            0.0098925  | False         |
+| T.4Nve.LN                       |   1.37083e-08 |            0.0120702  | False         |
+| T.4.LN.BDC                      |   1.47838e-08 |            0.012287   | False         |
+| LN.TR.14w.B6                    |   1.06239e-08 |            0.0138859  | False         |
+| MF.480int.LV.Naive              |   8.75148e-09 |            0.014214   | False         |
+| MF.480hi.LV.Naive               |   9.3381e-09  |            0.0170341  | False         |
+
+This is perhaps to be expected, as LDL levels are at least primarily not the consequence of an autoimmune process.
+
+
+## Cahoy and GTEx-Brain data
+
+The next two reference datasets pertain to the central nervous system.  Again, there are no significant hits.  The top non-significant hits are:
+
+| Name            |   Coefficient |   Coefficient_P_value | Reject Null   |
+|:----------------|--------------:|----------------------:|:--------------|
+| Astrocyte       |   1.97982e-09 |              0.291024 | False         |
+| Neuron          |   2.33232e-10 |              0.466565 | False         |
+| Oligodendrocyte |  -5.54881e-09 |              0.936155 | False         |⏎   
+
+and 
+
+| Name                                    |   Coefficient |   Coefficient_P_value | Reject Null   |
+|:----------------------------------------|--------------:|----------------------:|:--------------|
+| Brain_Nucleus_accumbens_(basal_ganglia) |   6.56949e-09 |             0.0297949 | False         |
+| Brain_Caudate_(basal_ganglia)           |   4.43273e-09 |             0.0727096 | False         |
+| Brain_Putamen_(basal_ganglia)           |   3.45177e-09 |             0.0808186 | False         |
+| Brain_Anterior_cingulate_cortex_(BA24)  |   1.83247e-09 |             0.249405  | False         |
+| Brain_Cortex                            |   1.85239e-09 |             0.282159  | False         |
+| Brain_Cerebellar_Hemisphere             |   1.55714e-09 |             0.334468  | False         |
+| Brain_Substantia_nigra                  |   8.98458e-10 |             0.387369  | False         |
+| Brain_Cerebellum                        |  -9.68139e-10 |             0.584834  | False         |
+
+This is perhaps to be expected, given the lack of significant hits on any CNS-related categories in the coarse-grained chromatin and gene expression datasets.

--- a/mecfs_bio/asset_generator/concrete_sldsc_generator.py
+++ b/mecfs_bio/asset_generator/concrete_sldsc_generator.py
@@ -25,6 +25,9 @@ from mecfs_bio.assets.reference_data.linkage_disequilibrium_score_reference_data
 from mecfs_bio.assets.reference_data.linkage_disequilibrium_score_reference_data.from_papers.finucane_2018_franke_gtex_categories import (
     FICUANE_2018_FRANKE_GTEX_CATEGORIES,
 )
+from mecfs_bio.assets.reference_data.linkage_disequilibrium_score_reference_data.from_papers.finucane_2018_immgen_categories import (
+    FICUANE_2018_IMMGEN_CATEGORIES,
+)
 from mecfs_bio.build_system.task.base_task import Task
 from mecfs_bio.build_system.task.pipes.composite_pipe import CompositePipe
 from mecfs_bio.build_system.task.pipes.str_lowercase_pipe import StrLowercasePipe
@@ -72,7 +75,27 @@ def standard_sldsc_task_generator(
             PartitionedLDScoresRecord(
                 ref_ld_chr_cts_task=PARTITIONED_MODEL_IMMGEN_LD_SCORES_EXTRACTED,
                 ref_ld_chr_cts_filename="ImmGen.ldcts",
-                cell_or_tissue_labels_task=None,
+                cell_or_tissue_labels_task=CellOrTissueLabelRecord(
+                    FICUANE_2018_IMMGEN_CATEGORIES,
+                    pipe_left=CompositePipe(
+                        [
+                            StrLowercasePipe(
+                                target_column="Name",
+                                new_column_name="lower case name",
+                            ),
+                        ],
+                    ),
+                    pipe_right=CompositePipe(
+                        [
+                            StrLowercasePipe(
+                                target_column="Cell Type",
+                                new_column_name="lower case name",
+                            )
+                        ]
+                    ),
+                    left_join_on="lower case name",
+                    right_join_on="lower case name",
+                ),
                 entry_name="immgen",
             ),
             PartitionedLDScoresRecord(

--- a/mecfs_bio/assets/reference_data/linkage_disequilibrium_score_reference_data/from_papers/finucane_2018_immgen_categories.py
+++ b/mecfs_bio/assets/reference_data/linkage_disequilibrium_score_reference_data/from_papers/finucane_2018_immgen_categories.py
@@ -1,0 +1,34 @@
+"""
+Categories for mouse immune cell types from the immgen project
+
+source:
+Suplementary Table 10 in
+Supplementary material to
+Finucane, Hilary K., et al. "Heritability enrichment of specifically expressed genes identifies disease-relevant tissues and cell types." Nature genetics 50.4 (2018): 621-629.
+
+"""
+
+from pathlib import PurePath
+
+from mecfs_bio.build_system.meta.read_spec.dataframe_read_spec import (
+    DataFrameReadSpec,
+    DataFrameTextFormat,
+)
+from mecfs_bio.build_system.meta.reference_meta.reference_file_meta import (
+    ReferenceFileMeta,
+)
+from mecfs_bio.build_system.task.download_file_task import DownloadFileTask
+
+FICUANE_2018_IMMGEN_CATEGORIES = DownloadFileTask(
+    meta=ReferenceFileMeta(
+        asset_id="ficuane_2018_immgen_categories",
+        group="linkage_disequilibrium_score_regression_aux_data",
+        sub_group="data_from_papers",
+        sub_folder=PurePath("ficuane_2018"),
+        filename="ficuane_2018_immgen_categories.csv",
+        extension=".csv",
+        read_spec=DataFrameReadSpec(DataFrameTextFormat(separator=",")),
+    ),
+    url="https://www.dropbox.com/scl/fi/587e0eypohr2azdlt0x54/Finucane_2018_Immgen_categories.csv?rlkey=nmjm7nrrpinqpm78q9wrbfft0&dl=1",
+    md5_hash="6a1d3c65ace87be0be6f56bd493eb3db",
+)


### PR DESCRIPTION
- Using supplementary table 10 from the Finucane  2018 paper, assign labels to the various cell types found in the immgen-based reference datasets for S-LDSC
- Apply this analysis to LDL (in the case of LDL, none of the immgen cells are significant.)