### PR TITLE
Add a pipe to set a column to a constant value

### DIFF
--- a/mecfs_bio/build_system/task/pipes/data_processing_pipe.py
+++ b/mecfs_bio/build_system/task/pipes/data_processing_pipe.py
@@ -4,6 +4,10 @@ import narwhals
 
 
 class DataProcessingPipe(ABC):
+    """
+    Abstract class representing a transformation of a lazy dataframe.
+    """
+
     @abstractmethod
     def process(self, x: narwhals.LazyFrame) -> narwhals.LazyFrame:
         pass

--- a/mecfs_bio/build_system/task/pipes/set_col_pipe.py
+++ b/mecfs_bio/build_system/task/pipes/set_col_pipe.py
@@ -1,0 +1,13 @@
+import narwhals
+from attrs import frozen
+
+from mecfs_bio.build_system.task.pipes.data_processing_pipe import DataProcessingPipe
+
+
+@frozen
+class SetColToConstantPipe(DataProcessingPipe):
+    col_name: str
+    constant: str | int | float
+
+    def process(self, x: narwhals.LazyFrame) -> narwhals.LazyFrame:
+        return x.with_columns(narwhals.lit(self.constant).alias(self.col_name))

--- a/test_mecfs_bio/unit/build_system/task/test_pipe/test_set_col_pipe.py
+++ b/test_mecfs_bio/unit/build_system/task/test_pipe/test_set_col_pipe.py
@@ -1,0 +1,13 @@
+import narwhals
+import pandas as pd
+
+from mecfs_bio.build_system.task.pipes.set_col_pipe import SetColToConstantPipe
+
+
+def test_set_col_pipe():
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    nw_frame = narwhals.from_native(df).lazy()
+    pipe = SetColToConstantPipe(col_name="b", constant=5)
+    result = pipe.process(nw_frame)
+    pd_result = result.collect().to_pandas()
+    assert (pd_result["b"] == 5).all()


### PR DESCRIPTION
- Several downstream analyses require a constant column indicating GWAS sample size.
- Certain GWAS datasets indicate sample size in documentation, but not in the GWAS summary statistics.
- Thus we need to create a synthetic constant column indicating sample size
- Add a pipe to do this.