### PR TITLE
Extend Build System Docs

### DIFF
--- a/docs/Codebase_Concepts/Build_System.md
+++ b/docs/Codebase_Concepts/Build_System.md
@@ -1,9 +1,45 @@
 # Build System
 
 ## Motivation
-In data science, the final product of an analysis is often the result of long pipeline of many steps.  These steps can be a mixture of pure data cleaning operations with more complex analysis and modeling.  Moreover, when the data size is nontrivial the steps and therefore the whole pipeline can be quite slow.  This scenario creates two challenges:
+In data science, the final product of an analysis is often the result of long pipeline of many steps.  These steps can be a mixture of pure data cleaning operations with more complex analysis and modeling.  Moreover, when the data size is nontrivial, the steps and therefore the whole pipeline can be quite slow.  This scenario creates two challenges:
 
 - **Iteration**: It is rare to run a pipeline once, produce an analysis, and be done with it. Usually, it is necessary to repeatedly tweak the steps, re-run the pipeline, and examine the result.  To avoid wasting time, it is therefore desirable that after each change, only the steps impacted by the change should be rerun.
 - **Lineage**:  Given the complexity of many data science workflows, there is considerable room of error.  It is therefore desirable to be able to interrogate the final product of a workflow to trace its "lineage": the precise series of steps that produced it.
 
-These challenges motivate the development of a build system.
+These challenges motivate the development of a data science build system.
+
+## Framework 
+
+The build system used in this project is heavily based on the framework described by Mokhov et al. in their prize-winning papers[@mokhov2018build] [@mokhov2020build].  
+
+## Key Concepts
+
+### Asset
+
+An asset is any file or directory relevant to the build.  Examples of assets include:
+
+
+- GWAS summary statistics
+- Reference RNAseq data from the GTEx project
+- Plots illustrating the results of applying MAGMA to GWAS summary statistics.
+
+
+### Task
+
+A task is an operation that constructs a particular asset.
+
+Here is the source code for the `Task` base class:
+
+```python title="Task Class definition"
+--8<-- "mecfs_bio/build_system/task/base_task.py"
+```
+
+
+- The `meta` property returns a metadata object (see below) describing the asset created by the Task. This metadata object must include a string `AssetId` uniquely identifying the asset.
+- The `deps` property returns a list of pre-requisite Tasks that must be executed prior to the current Task.  The build system uses `deps` to construct the dependency graph of Tasks.
+- The key method is `execute`. Subclasses must override this method to specify how to construct their assets.  The `fetch` parameter is a special callback passed to `execute` by the build system.  Instead of directly accessing its dependencies, `execute` should use `fetch` to access dependencies via the build system
+
+
+Concrete Task subclass classes are defined [here][mecfs_bio.build_system.task].
+
+

--- a/docs/Data_Sources/Roadmap_Epigenetic_Project/Roadmap.md
+++ b/docs/Data_Sources/Roadmap_Epigenetic_Project/Roadmap.md
@@ -5,7 +5,7 @@
 The Roadmap Epigenetics Project[@bernstein2010nih] was an NIH-funded data-collection initiative whose aim was to gather [epigenic data](../../Bioinformatics_Concepts/Epigenetics.md) such as:
 
 - DNA methylation data
-- [Histone modification data](../../Bioinformatics_Concepts/Epigenetics.md#example-histone-marks)
+- [Histone modification data](../../Bioinformatics_Concepts/Epigenetics.md#histone-marks)
 - Chromatin accessibility data (via the DNase 1 chromatin accesbility assay),
 
 from a wide variety of human tissue.

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -150,3 +150,24 @@
   year={2016},
   publisher={Nature Publishing Group US New York}
 }
+
+@article{mokhov2018build,
+  title={Build systems {\`a} la carte},
+  author={Mokhov, Andrey and Mitchell, Neil and Peyton Jones, Simon},
+  journal={Proceedings of the ACM on Programming Languages},
+  volume={2},
+  number={ICFP},
+  pages={1--29},
+  year={2018},
+  publisher={ACM New York, NY, USA}
+}
+
+@article{mokhov2020build,
+  title={Build systems {\`a} la carte: Theory and practice},
+  author={Mokhov, Andrey and Mitchell, Neil and Jones, Simon Peyton},
+  journal={Journal of Functional Programming},
+  volume={30},
+  pages={e11},
+  year={2020},
+  publisher={Cambridge University Press}
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,3 +42,10 @@ markdown_extensions:
   - pymdownx.arithmatex:
       generic: true
   - footnotes
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences


### PR DESCRIPTION
- Extend my documentation of the build system by writing a section on the `Task` class.
- This section includes a code snippet.  To facilitate the inclusion of code snippets in documentation, add the approrpiate mkdocs plugin.