### PR TITLE
use_tempdir_for_system_test

### DIFF
--- a/test_mecfs_bio/system/test_decode_me_initial_analysis.py
+++ b/test_mecfs_bio/system/test_decode_me_initial_analysis.py
@@ -1,6 +1,8 @@
+import tempfile
+from pathlib import Path
+
 import pandas as pd
 
-from mecfs_bio.analysis.runner.default_runner import DEFAULT_RUNNER
 from mecfs_bio.assets.gwas.me_cfs.decode_me.analysis.decode_me_gwas_1_lead_variants import (
     DECODE_ME_GWAS_1_LEAD_VARIANTS,
 )
@@ -11,6 +13,10 @@ from mecfs_bio.assets.gwas.me_cfs.decode_me.analysis.decode_me_gwas_1_manhattan_
     DECODE_ME_GWAS_1_MANHATTAN_AND_QQ_PLOT,
 )
 from mecfs_bio.build_system.asset.file_asset import FileAsset
+from mecfs_bio.build_system.rebuilder.verifying_trace_rebuilder.tracer.imohash import (
+    ImoHasher,
+)
+from mecfs_bio.build_system.runner.simple_runner import SimpleRunner
 from mecfs_bio.build_system.task.gwaslab.gwaslab_constants import GWASLAB_SNPID_COL
 
 expected_vars = {
@@ -31,15 +37,25 @@ def test_run_initial_analysis():
     - Produce Manhattan plots
 
     """
-    result = DEFAULT_RUNNER.run(
-        [
-            DECODE_ME_GWAS_1_MANHATTAN_AND_QQ_PLOT,
-            DECODE_ME_GWAS_1_MANHATTAN_PLOT,
-            DECODE_ME_GWAS_1_LEAD_VARIANTS,
-        ]
-    )
-    variants_asset = result[DECODE_ME_GWAS_1_LEAD_VARIANTS.asset_id]
-    assert isinstance(variants_asset, FileAsset)
-    df: pd.DataFrame = pd.read_csv(variants_asset.path, index_col=None)
-    lead_vars = set(df[GWASLAB_SNPID_COL].tolist())
-    assert expected_vars == lead_vars
+    with tempfile.TemporaryDirectory() as tempdirname:
+        tempdir = Path(tempdirname)
+        info_store = tempdir / "info_store.yaml"
+        asset_root = tempdir / "asset_store"
+        asset_root.mkdir(parents=True, exist_ok=True)
+        test_runner = SimpleRunner(
+            tracer=ImoHasher.with_xxhash_128(),
+            info_store=info_store,
+            asset_root=asset_root,
+        )
+        result = test_runner.run(
+            [
+                DECODE_ME_GWAS_1_MANHATTAN_AND_QQ_PLOT,
+                DECODE_ME_GWAS_1_MANHATTAN_PLOT,
+                DECODE_ME_GWAS_1_LEAD_VARIANTS,
+            ]
+        )
+        variants_asset = result[DECODE_ME_GWAS_1_LEAD_VARIANTS.asset_id]
+        assert isinstance(variants_asset, FileAsset)
+        df: pd.DataFrame = pd.read_csv(variants_asset.path, index_col=None)
+        lead_vars = set(df[GWASLAB_SNPID_COL].tolist())
+        assert expected_vars == lead_vars


### PR DESCRIPTION
- Instead of running integration test in main asset directory, run it in a temporary directory.  This improves test isolation.
- Closes #177 