### PR TITLE
Include API docs even without docstring

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,7 +28,7 @@ plugins:
           show_signature_annotations: true
           show_symbol_type_heading: true
           show_symbol_type_toc: true
-          show_if_no_docstring: false
+          show_if_no_docstring: true
           summary: true
 - api-autonav:
     modules: ['mecfs_bio']


### PR DESCRIPTION
- Currently, I use mkdocsstrings to auto-generate api docs for functions and classes that have docstrings.
- Thing PR changes the configuration options so that we auto-generate api docs even for functions and classes without docstrings.