### PR TITLE
Ignore localhost in link checker

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,1 @@
+http://localhost:8000/


### PR DESCRIPTION
The lychee link checker fails after trying to access localhost.  add localhost to ignore list