### PR TITLE
Use Wrapper to improve system test

### DIFF
--- a/mecfs_bio/asset_generator/concrete_sldsc_generator.py
+++ b/mecfs_bio/asset_generator/concrete_sldsc_generator.py
@@ -6,22 +6,22 @@ from mecfs_bio.assets.reference_data.linkage_disequilibrium_score_reference_data
     ROADMAP_CELL_TYPE_CATEGORIES_FOR_LDSC,
 )
 from mecfs_bio.assets.reference_data.linkage_disequilibrium_score_reference_data.extracted.partitioned_model_cahoy_ld_scores_extracted import (
-    PARTITIONED_MODEL_CAHOY_LD_SCORES_EXTRACTED,
+    PARTITIONED_MODEL_CAHOY_LD_SCORES_EXTRACTED_RD,
 )
 from mecfs_bio.assets.reference_data.linkage_disequilibrium_score_reference_data.extracted.partitioned_model_corces_atac_ld_scores_extracted import (
-    PARTITIONED_MODEL_CORCES_ATAC_LD_SCORES_EXTRACTED,
+    PARTITIONED_MODEL_CORCES_ATAC_LD_SCORES_EXTRACTED_RD,
 )
 from mecfs_bio.assets.reference_data.linkage_disequilibrium_score_reference_data.extracted.partitioned_model_gtex_brain_ld_scores_extracted import (
-    PARTITIONED_MODEL_GTEX_BRAIN_LD_SCORES_EXTRACTED,
+    PARTITIONED_MODEL_GTEX_BRAIN_LD_SCORES_EXTRACTED_RD,
 )
 from mecfs_bio.assets.reference_data.linkage_disequilibrium_score_reference_data.extracted.partitioned_model_immgen_ld_scores_extracted import (
-    PARTITIONED_MODEL_IMMGEN_LD_SCORES_EXTRACTED,
+    PARTITIONED_MODEL_IMMGEN_LD_SCORES_EXTRACTED_RD,
 )
 from mecfs_bio.assets.reference_data.linkage_disequilibrium_score_reference_data.extracted.partitioned_model_multi_tissue_chromatin_ld_scores_extracted import (
-    PARTITIONED_MODEL_MULTI_TISSUE_CHROMATIN_LD_SCORES_EXTRACTED,
+    PARTITIONED_MODEL_MULTI_TISSUE_CHROMATIN_LD_SCORES_EXTRACTED_RD,
 )
 from mecfs_bio.assets.reference_data.linkage_disequilibrium_score_reference_data.extracted.partitioned_model_multi_tissue_gene_expr_ld_score_extracted import (
-    PARTITIONED_MODEL_MULTI_TISSUE_GENE_EXPR_LD_SCORES_EXTRACTED,
+    PARTITIONED_MODEL_MULTI_TISSUE_GENE_EXPR_LD_SCORES_EXTRACTED_RD,
 )
 from mecfs_bio.assets.reference_data.linkage_disequilibrium_score_reference_data.extracted.partitioned_model_regression_weights_extracted import (
     PARTITIONED_MODEL_REGRESSION_WEIGHTS_EXTRACTED,
@@ -72,19 +72,19 @@ def standard_sldsc_task_generator(
         w_ld_chr_inner_dirname="1000G_Phase3_weights_hm3_no_MHC/weights.hm3_noMHC.@",
         partitioned_entries=[
             PartitionedLDScoresRecord(
-                ref_ld_chr_cts_task=PARTITIONED_MODEL_CAHOY_LD_SCORES_EXTRACTED,
+                ref_ld_chr_cts_task=PARTITIONED_MODEL_CAHOY_LD_SCORES_EXTRACTED_RD,
                 ref_ld_chr_cts_filename="Cahoy.ldcts",
                 cell_or_tissue_labels_task=None,
                 entry_name="cahoy_cns",
             ),
             PartitionedLDScoresRecord(
-                ref_ld_chr_cts_task=PARTITIONED_MODEL_GTEX_BRAIN_LD_SCORES_EXTRACTED,
+                ref_ld_chr_cts_task=PARTITIONED_MODEL_GTEX_BRAIN_LD_SCORES_EXTRACTED_RD,
                 ref_ld_chr_cts_filename="GTEx_brain.ldcts",
                 cell_or_tissue_labels_task=None,
                 entry_name="gtex_brain",
             ),
             PartitionedLDScoresRecord(
-                ref_ld_chr_cts_task=PARTITIONED_MODEL_IMMGEN_LD_SCORES_EXTRACTED,
+                ref_ld_chr_cts_task=PARTITIONED_MODEL_IMMGEN_LD_SCORES_EXTRACTED_RD,
                 ref_ld_chr_cts_filename="ImmGen.ldcts",
                 cell_or_tissue_labels_task=CellOrTissueLabelRecord(
                     FICUANE_2018_IMMGEN_CATEGORIES,
@@ -110,13 +110,13 @@ def standard_sldsc_task_generator(
                 entry_name="immgen",
             ),
             PartitionedLDScoresRecord(
-                ref_ld_chr_cts_task=PARTITIONED_MODEL_CORCES_ATAC_LD_SCORES_EXTRACTED,
+                ref_ld_chr_cts_task=PARTITIONED_MODEL_CORCES_ATAC_LD_SCORES_EXTRACTED_RD,
                 ref_ld_chr_cts_filename="Corces_ATAC.ldcts",
                 cell_or_tissue_labels_task=None,
                 entry_name="corces_atac",
             ),
             PartitionedLDScoresRecord(
-                ref_ld_chr_cts_task=PARTITIONED_MODEL_MULTI_TISSUE_CHROMATIN_LD_SCORES_EXTRACTED,
+                ref_ld_chr_cts_task=PARTITIONED_MODEL_MULTI_TISSUE_CHROMATIN_LD_SCORES_EXTRACTED_RD,
                 ref_ld_chr_cts_filename="Multi_tissue_chromatin.ldcts",
                 entry_name="multi_tissue_chromatin",
                 cell_or_tissue_labels_task=CellOrTissueLabelRecord(
@@ -152,7 +152,7 @@ def standard_sldsc_task_generator(
                 ),
             ),
             PartitionedLDScoresRecord(
-                ref_ld_chr_cts_task=PARTITIONED_MODEL_MULTI_TISSUE_GENE_EXPR_LD_SCORES_EXTRACTED,
+                ref_ld_chr_cts_task=PARTITIONED_MODEL_MULTI_TISSUE_GENE_EXPR_LD_SCORES_EXTRACTED_RD,
                 ref_ld_chr_cts_filename="Multi_tissue_gene_expr.ldcts",
                 cell_or_tissue_labels_task=CellOrTissueLabelRecord(
                     FICUANE_2018_FRANKE_GTEX_CATEGORIES,

--- a/mecfs_bio/assets/reference_data/db_snp/db_sn150_build_37_annovar_proc_parquet.py
+++ b/mecfs_bio/assets/reference_data/db_snp/db_sn150_build_37_annovar_proc_parquet.py
@@ -1,13 +1,18 @@
 from mecfs_bio.assets.reference_data.db_snp.db_snp150_build_37_annovar_proc import (
-    DB_SNP150_ANNOVAR_PROC,
+    DB_SNP150_ANNOVAR_PROC_RD,
 )
 from mecfs_bio.build_system.task.compressed_csv_to_parquet_task import (
     CompressedCSVToParquetTask,
 )
+from mecfs_bio.build_system.task.discard_deps_task_wrapper import DiscardDepsWrapper
 
 PARQUET_DBSNP150_37_ANNOVAR_PROC = CompressedCSVToParquetTask.create(
-    csv_task=DB_SNP150_ANNOVAR_PROC,
+    csv_task=DB_SNP150_ANNOVAR_PROC_RD,
     asset_id="db_snp150_annovar_proc_parquet",
     source_compression=None,
     type_dict={"CHROM": "VARCHAR"},
+)
+
+PARQUET_DBSNP150_37_ANNOVAR_PROC_RD = DiscardDepsWrapper(
+    PARQUET_DBSNP150_37_ANNOVAR_PROC
 )

--- a/mecfs_bio/assets/reference_data/db_snp/db_sn150_build_37_annovar_proc_parquet_rename.py
+++ b/mecfs_bio/assets/reference_data/db_snp/db_sn150_build_37_annovar_proc_parquet_rename.py
@@ -4,11 +4,12 @@ those used by gwaslab
 """
 
 from mecfs_bio.assets.reference_data.db_snp.db_sn150_build_37_annovar_proc_parquet import (
-    PARQUET_DBSNP150_37_ANNOVAR_PROC,
+    PARQUET_DBSNP150_37_ANNOVAR_PROC_RD,
 )
 from mecfs_bio.build_system.reference.schemas.chrom_rename_rules import (
     CHROM_RENAME_DF_NUMERIC_X_Y_M,
 )
+from mecfs_bio.build_system.task.discard_deps_task_wrapper import DiscardDepsWrapper
 from mecfs_bio.build_system.task.pipe_dataframe_task import (
     ParquetOutFormat,
     PipeDataFrameTask,
@@ -20,7 +21,7 @@ from mecfs_bio.build_system.task.pipes.sort_pipe import SortPipe
 
 PARQUET_DBSNP150_37_ANNOVAR_PROC_RENAME = PipeDataFrameTask.create(
     asset_id="db_snp150_annovar_proc_parquet_rename",
-    source_task=PARQUET_DBSNP150_37_ANNOVAR_PROC,
+    source_task=PARQUET_DBSNP150_37_ANNOVAR_PROC_RD,
     pipes=[
         JoinWithMemTablePipe(
             CHROM_RENAME_DF_NUMERIC_X_Y_M,
@@ -32,4 +33,8 @@ PARQUET_DBSNP150_37_ANNOVAR_PROC_RENAME = PipeDataFrameTask.create(
     ],
     out_format=ParquetOutFormat(),
     backend="ibis",
+)
+
+PARQUET_DBSNP150_37_ANNOVAR_PROC_RENAME_RD = DiscardDepsWrapper(
+    PARQUET_DBSNP150_37_ANNOVAR_PROC_RENAME
 )

--- a/mecfs_bio/assets/reference_data/db_snp/db_sn150_build_37_annovar_proc_parquet_rename_unique.py
+++ b/mecfs_bio/assets/reference_data/db_snp/db_sn150_build_37_annovar_proc_parquet_rename_unique.py
@@ -12,7 +12,7 @@ the S-LDSC reference data.
 """
 
 from mecfs_bio.assets.reference_data.db_snp.db_sn150_build_37_annovar_proc_parquet_rename import (
-    PARQUET_DBSNP150_37_ANNOVAR_PROC_RENAME,
+    PARQUET_DBSNP150_37_ANNOVAR_PROC_RENAME_RD,
 )
 from mecfs_bio.build_system.task.pipe_dataframe_task import (
     ParquetOutFormat,
@@ -23,7 +23,7 @@ from mecfs_bio.build_system.task.pipes.uniquepipe import UniquePipe
 
 PARQUET_DBSNP150_37_ANNOVAR_PROC_RENAME_UNIQUE = PipeDataFrameTask.create(
     asset_id="db_snp150_annovar_proc_parquet_rename_unique",
-    source_task=PARQUET_DBSNP150_37_ANNOVAR_PROC_RENAME,
+    source_task=PARQUET_DBSNP150_37_ANNOVAR_PROC_RENAME_RD,
     pipes=[
         DuckdbMemLimitPipe(limit_gb=4),
         UniquePipe(

--- a/mecfs_bio/assets/reference_data/db_snp/db_snp150_build_37_annovar_proc.py
+++ b/mecfs_bio/assets/reference_data/db_snp/db_snp150_build_37_annovar_proc.py
@@ -7,6 +7,7 @@ from mecfs_bio.build_system.meta.read_spec.dataframe_read_spec import (
 from mecfs_bio.build_system.meta.reference_meta.reference_file_meta import (
     ReferenceFileMeta,
 )
+from mecfs_bio.build_system.task.discard_deps_task_wrapper import DiscardDepsWrapper
 from mecfs_bio.build_system.task.download_file_task import DownloadFileTask
 
 """
@@ -46,3 +47,5 @@ DB_SNP150_ANNOVAR_PROC = DownloadFileTask(
     url="https://www.dropbox.com/scl/fi/rvonq6jk3o88mtzc83mrn/hg19_avsnp150.txt?rlkey=gitowj4jrw2wjzbx2uyqi2xxp&dl=1",
     md5_hash="c17e8f96e9b36041455069be9c459555",
 )
+
+DB_SNP150_ANNOVAR_PROC_RD = DiscardDepsWrapper(DB_SNP150_ANNOVAR_PROC)

--- a/mecfs_bio/assets/reference_data/linkage_disequilibrium_score_reference_data/extracted/partitioned_model_cahoy_ld_scores_extracted.py
+++ b/mecfs_bio/assets/reference_data/linkage_disequilibrium_score_reference_data/extracted/partitioned_model_cahoy_ld_scores_extracted.py
@@ -1,10 +1,15 @@
 from mecfs_bio.assets.reference_data.linkage_disequilibrium_score_reference_data.raw.partitioned_model_cahoy_ld_scores import (
     PARTITIONED_MODEL_CAHOY_LD_SCORES_RAW,
 )
+from mecfs_bio.build_system.task.discard_deps_task_wrapper import DiscardDepsWrapper
 from mecfs_bio.build_system.task.extract_tar_gzip_task import ExtractTarGzipTask
 
 PARTITIONED_MODEL_CAHOY_LD_SCORES_EXTRACTED = ExtractTarGzipTask.create(
     asset_id="partitioned_model_cahoy_ld_scores_extracted",
     source_task=PARTITIONED_MODEL_CAHOY_LD_SCORES_RAW,
     read_mode="r",
+)
+
+PARTITIONED_MODEL_CAHOY_LD_SCORES_EXTRACTED_RD = DiscardDepsWrapper(
+    PARTITIONED_MODEL_CAHOY_LD_SCORES_EXTRACTED
 )

--- a/mecfs_bio/assets/reference_data/linkage_disequilibrium_score_reference_data/extracted/partitioned_model_corces_atac_ld_scores_extracted.py
+++ b/mecfs_bio/assets/reference_data/linkage_disequilibrium_score_reference_data/extracted/partitioned_model_corces_atac_ld_scores_extracted.py
@@ -1,10 +1,14 @@
 from mecfs_bio.assets.reference_data.linkage_disequilibrium_score_reference_data.raw.partitioned_model_corces_atac import (
     PARTITIONED_MODEL_CORCES_ATAC_LD_SCORES_RAW,
 )
+from mecfs_bio.build_system.task.discard_deps_task_wrapper import DiscardDepsWrapper
 from mecfs_bio.build_system.task.extract_tar_gzip_task import ExtractTarGzipTask
 
 PARTITIONED_MODEL_CORCES_ATAC_LD_SCORES_EXTRACTED = ExtractTarGzipTask.create(
     asset_id="partitioned_model_corces_atac_ld_scores_extracted",
     source_task=PARTITIONED_MODEL_CORCES_ATAC_LD_SCORES_RAW,
     read_mode="r",
+)
+PARTITIONED_MODEL_CORCES_ATAC_LD_SCORES_EXTRACTED_RD = DiscardDepsWrapper(
+    PARTITIONED_MODEL_CORCES_ATAC_LD_SCORES_EXTRACTED
 )

--- a/mecfs_bio/assets/reference_data/linkage_disequilibrium_score_reference_data/extracted/partitioned_model_gtex_brain_ld_scores_extracted.py
+++ b/mecfs_bio/assets/reference_data/linkage_disequilibrium_score_reference_data/extracted/partitioned_model_gtex_brain_ld_scores_extracted.py
@@ -1,10 +1,14 @@
 from mecfs_bio.assets.reference_data.linkage_disequilibrium_score_reference_data.raw.partitioned_model_gtex_brain_ld_scores import (
     PARTITIONED_MODEL_GTEX_BRAIN_LD_SCORES_RAW,
 )
+from mecfs_bio.build_system.task.discard_deps_task_wrapper import DiscardDepsWrapper
 from mecfs_bio.build_system.task.extract_tar_gzip_task import ExtractTarGzipTask
 
 PARTITIONED_MODEL_GTEX_BRAIN_LD_SCORES_EXTRACTED = ExtractTarGzipTask.create(
     asset_id="partitioned_model_gtex_brain_ld_scores_extracted",
     source_task=PARTITIONED_MODEL_GTEX_BRAIN_LD_SCORES_RAW,
     read_mode="r",
+)
+PARTITIONED_MODEL_GTEX_BRAIN_LD_SCORES_EXTRACTED_RD = DiscardDepsWrapper(
+    PARTITIONED_MODEL_GTEX_BRAIN_LD_SCORES_EXTRACTED
 )

--- a/mecfs_bio/assets/reference_data/linkage_disequilibrium_score_reference_data/extracted/partitioned_model_immgen_ld_scores_extracted.py
+++ b/mecfs_bio/assets/reference_data/linkage_disequilibrium_score_reference_data/extracted/partitioned_model_immgen_ld_scores_extracted.py
@@ -1,10 +1,14 @@
 from mecfs_bio.assets.reference_data.linkage_disequilibrium_score_reference_data.raw.partitioned_model_immgen_ld_scores import (
     PARTITIONED_MODEL_IMMGEN_LD_SCORES_RAW,
 )
+from mecfs_bio.build_system.task.discard_deps_task_wrapper import DiscardDepsWrapper
 from mecfs_bio.build_system.task.extract_tar_gzip_task import ExtractTarGzipTask
 
 PARTITIONED_MODEL_IMMGEN_LD_SCORES_EXTRACTED = ExtractTarGzipTask.create(
     asset_id="partitioned_model_immgen_ld_scores_extracted",
     source_task=PARTITIONED_MODEL_IMMGEN_LD_SCORES_RAW,
     read_mode="r",
+)
+PARTITIONED_MODEL_IMMGEN_LD_SCORES_EXTRACTED_RD = DiscardDepsWrapper(
+    PARTITIONED_MODEL_IMMGEN_LD_SCORES_EXTRACTED
 )

--- a/mecfs_bio/assets/reference_data/linkage_disequilibrium_score_reference_data/extracted/partitioned_model_multi_tissue_chromatin_ld_scores_extracted.py
+++ b/mecfs_bio/assets/reference_data/linkage_disequilibrium_score_reference_data/extracted/partitioned_model_multi_tissue_chromatin_ld_scores_extracted.py
@@ -1,6 +1,7 @@
 from mecfs_bio.assets.reference_data.linkage_disequilibrium_score_reference_data.raw.partitioned_model_multi_tissue_chromatin_ld_scores import (
     PARTITIONED_MODEL_MULTI_TISSUE_CHROMATIN_LD_SCORES_RAW,
 )
+from mecfs_bio.build_system.task.discard_deps_task_wrapper import DiscardDepsWrapper
 from mecfs_bio.build_system.task.extract_tar_gzip_task import ExtractTarGzipTask
 
 PARTITIONED_MODEL_MULTI_TISSUE_CHROMATIN_LD_SCORES_EXTRACTED = (
@@ -9,4 +10,7 @@ PARTITIONED_MODEL_MULTI_TISSUE_CHROMATIN_LD_SCORES_EXTRACTED = (
         source_task=PARTITIONED_MODEL_MULTI_TISSUE_CHROMATIN_LD_SCORES_RAW,
         read_mode="r",
     )
+)
+PARTITIONED_MODEL_MULTI_TISSUE_CHROMATIN_LD_SCORES_EXTRACTED_RD = DiscardDepsWrapper(
+    PARTITIONED_MODEL_MULTI_TISSUE_CHROMATIN_LD_SCORES_EXTRACTED
 )

--- a/mecfs_bio/assets/reference_data/linkage_disequilibrium_score_reference_data/extracted/partitioned_model_multi_tissue_gene_expr_ld_score_extracted.py
+++ b/mecfs_bio/assets/reference_data/linkage_disequilibrium_score_reference_data/extracted/partitioned_model_multi_tissue_gene_expr_ld_score_extracted.py
@@ -1,10 +1,14 @@
 from mecfs_bio.assets.reference_data.linkage_disequilibrium_score_reference_data.raw.partitioned_model_multi_tissue_gene_expr_ld_scores import (
     THOUSAND_GENOME_PARTITIONED_MODEL_MULTI_TISSUE_GENE_EXPR_LD_SCORES_RAW,
 )
+from mecfs_bio.build_system.task.discard_deps_task_wrapper import DiscardDepsWrapper
 from mecfs_bio.build_system.task.extract_tar_gzip_task import ExtractTarGzipTask
 
 PARTITIONED_MODEL_MULTI_TISSUE_GENE_EXPR_LD_SCORES_EXTRACTED = ExtractTarGzipTask.create(
     asset_id="multi_tissue_gene_expression_partitioned_ld_scores_extracted",
     source_task=THOUSAND_GENOME_PARTITIONED_MODEL_MULTI_TISSUE_GENE_EXPR_LD_SCORES_RAW,
     read_mode="r",
+)
+PARTITIONED_MODEL_MULTI_TISSUE_GENE_EXPR_LD_SCORES_EXTRACTED_RD = DiscardDepsWrapper(
+    PARTITIONED_MODEL_MULTI_TISSUE_GENE_EXPR_LD_SCORES_EXTRACTED
 )


### PR DESCRIPTION
- Use `DiscardDepsWrapper` to avoid permantly storing some very large downloaded files.  Goal is to reduce storage used by S-LDSC system test