### PR TITLE
Download figures when link checking

### DIFF
--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -18,6 +18,10 @@ jobs:
         with:
           pixi-version: v0.55.0
           cache: true
+      - name: Download figures
+        run: pixi r invoke pfig
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Check links
         run: pixi r invoke check-all-links
 

--- a/tasks.py
+++ b/tasks.py
@@ -10,6 +10,8 @@ USER_AGENT = '"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"'
 
 PULL_FIGURE_SCRIPT_PATH = Path("mecfs_bio/figures/key_scripts/pull_figures.py")
 
+FIGS_PATH = Path("docs/_figs/")
+
 
 # dev tasks
 @task
@@ -122,7 +124,9 @@ def check_local_links(c):
     Check local links with lychee
     """
     print("Checking offline links with lychee...")
-    c.run(f"pixi r lychee --offline {SRC_PATH} {DOCS_PATH}")
+    cmd = f"pixi r lychee  --offline {SRC_PATH} {DOCS_PATH}"
+    print(f"running {cmd}")
+    c.run(cmd)
 
 
 @task(
@@ -177,7 +181,7 @@ def serve_docs(c, strict: bool = False):
     if strict:
         cmd += " --strict"
     print("Serving documentation...")
-    print(f"runnng {cmd}")
+    print(f"running {cmd}")
     c.run(cmd, pty=True)
 
 


### PR DESCRIPTION
- Lychee link checker was failing in CI due to absence of figures in the CI environment (see https://github.com/trafalmadorian97/mecfs_bioinformatics/actions/runs/21995675629) .
- Fix this by downloading figures in CI environment