### PR TITLE
Link to Broad Institute Primer talk

### DIFF
--- a/docs/Bioinformatics_Concepts/Heritability.md
+++ b/docs/Bioinformatics_Concepts/Heritability.md
@@ -99,6 +99,10 @@ Todo[@leia2025heritability]
 
 
 
+# Links
+
+[Broad Institute Prime Talk on Heritability](https://www.youtube.com/watch?v=wM7yxJlvwe8)
+
 
 # References
 


### PR DESCRIPTION
- Add a link to the Broad institute's primer talk on heritability, which gives a high quality overview of the concept
