### PR TITLE
Add missing columns for when there are no significant genes

### DIFF
--- a/mecfs_bio/build_system/task/fetch_gget_info_task.py
+++ b/mecfs_bio/build_system/task/fetch_gget_info_task.py
@@ -37,7 +37,9 @@ logger = structlog.getLogger()
 
 _dummy_gget_result = pd.DataFrame(
     {
+        "primary_gene_name": [None],
         "ensembl_description": [None],
+        "uniprot_id": [None],
         "uniprot_description": [None],
         "ncbi_description": [None],
         "subcellular_localisation": [None],


### PR DESCRIPTION
The [`ConvertDataFrameToMarkdownTask`](https://github.com/trafalmadorian97/mecfs_bioinformatics/blob/4b807e6d0e56c45ef58649fd06e5c92ed40fcf0e/mecfs_bio/build_system/task_generator/master_gene_list_task_generator.py#L48) task fails if there are no genes in the master gene list, because the dummy dataframe provided in that case is missing some columns it expects. This adds those columns.