### PR TITLE
Remove drop nulls pipe

### DIFF
--- a/mecfs_bio/assets/gwas/multisite_pain/johnston_et_al/analysis/johnston_standard_analysis.py
+++ b/mecfs_bio/assets/gwas/multisite_pain/johnston_et_al/analysis/johnston_standard_analysis.py
@@ -12,7 +12,6 @@ from mecfs_bio.build_system.task.gwaslab.gwaslab_create_sumstats_task import (
     GWASLabColumnSpecifiers,
 )
 from mecfs_bio.build_system.task.magma.plot_magma_brain_atlas_result import PlotSettings
-from mecfs_bio.build_system.task.pipes.drop_null_pipe import DropNullsPipe
 
 JOHNSTON_ET_AL_PAIN_STANDARD_ANALYSIS = (
     concrete_standard_analysis_generator_assume_already_has_rsid(
@@ -31,7 +30,6 @@ JOHNSTON_ET_AL_PAIN_STANDARD_ANALYSIS = (
             p="P_BOLT_LMM_INF",
             eaf="A1FREQ",
         ),
-        pre_pipe=DropNullsPipe(),
         hba_plot_settings=PlotSettings("plotly_white"),
         include_independent_cluster_plot_in_hba=True,
     )


### PR DESCRIPTION
The GWAS data doesn't have any null rows, so the DropNullsPipe isn't needed.