### PR TITLE
Fix PGC file download

### DIFF
--- a/mecfs_bio/assets/gwas/schizophrenia/pgc2022/raw/raw_sch_pgc2022.py
+++ b/mecfs_bio/assets/gwas/schizophrenia/pgc2022/raw/raw_sch_pgc2022.py
@@ -30,6 +30,6 @@ PGC_2022_SCH_RAW = DownloadFileTask(
             format=DataFrameTextFormat(separator="\t", comment_char="#")
         ),
     ),
-    url="https://figshare.com/ndownloader/files/34517828",
+    url="https://ndownloader.figshare.com/files/34517828",
     md5_hash="6ebe2376f5cda972d37efa0f214c4df0",
 )


### PR DESCRIPTION
- I was getting errors when attempting to download the PGC Schizophrenia GWAS file.  I believe the issue was some kind of anti-bot protection.
- Gemini suggested using a different figshare link for the same file.
- This seems to work.