### PR TITLE
Fix navigation bar on one page

### DIFF
--- a/docs/Analysis/Verma_et_al_(LDL)/MAGMA_LDL_Analysis.md
+++ b/docs/Analysis/Verma_et_al_(LDL)/MAGMA_LDL_Analysis.md
@@ -1,6 +1,6 @@
 ---
 hide:
-    - navigation
+    - toc
 ---
 
 


### PR DESCRIPTION
One documentation page was showing the TOC instead of the navigation bar, opposite of other doc pages.