### PR TITLE
Add Zoomable images.  Improve documentation generally.

### DIFF
--- a/docs/Analysis/DecodeME/S-LDSC_DecodeME_Analysis.md
+++ b/docs/Analysis/DecodeME/S-LDSC_DecodeME_Analysis.md
@@ -181,7 +181,7 @@ When we apply the S-LDSC using the GTEx brain dataset, we find the the cortex ti
 | Brain_Cerebellar_Hemisphere             |   2.45686e-10 |           0.39188     | False         
 
 
-# Reproducing Analysis
+## How to Reproduce This
 
 To reproduce, run the [DecodeME Analysis Script][mecfs_bio.analysis.decode_me_initial_analysis].
 

--- a/docs/Analysis/Multitrait/Genetic_Correlation/CT-LDSC_Study.md
+++ b/docs/Analysis/Multitrait/Genetic_Correlation/CT-LDSC_Study.md
@@ -4,32 +4,35 @@ hide:
 ---
 # CT-LDSC Study
 
-I applied [cross-trait linkage disequilibrium score regression](../../../Bioinformatics_Concepts/Cross_Trait_LDSC.md)[@bulik2015atlas] to estimate [genetic correlation](../../../Bioinformatics_Concepts/Genetic_Correlation.md) between a diverse phenotypes, including the ME/CFS phenotype defined in DecodeME[@genetics2025initial].  The genetic correlations are plotted in the heatmap below. Cells with asterixes are Bonferroni-corrected statistically significant.
+I applied [cross-trait linkage disequilibrium score regression](../../../Bioinformatics_Concepts/Cross_Trait_LDSC.md)[@bulik2015atlas] to estimate [genetic correlation](../../../Bioinformatics_Concepts/Genetic_Correlation.md) between diverse phenotypes, including the ME/CFS phenotype defined in [DecodeME](../../../Data_Sources/DecodeME.md)[@genetics2025initial].  The genetic correlations are plotted in the heatmap below. Asterixes denote Bonferroni-corrected statistically significant correlations.
 
 <iframe src="../../../../_figs/initial_genetic_correlation_by_ct_ldsc_plot.html" style="width:100%; height:750px; border:none;"></iframe>
 
 The traits are:
 
-- **Asthma** from the GWAS of Han et al.[@han2020genome]  Several theories relating ME/CFS to the activation of mast cells (_todo: add citation_), but the evidence for these theories has is often anecdotal. I added asthma as a prototypical example of a common disease involving the IgE/ mast cell immune axis (See _Janeway's Immunobiology,_[@murphy2022janeway] _Chapter 14: Allergic Diseases_).
-- Diastolic blood pressure (**DBP**) from the Keaton et al.[@keaton2024genome] Several authors theorize that ME/CFS is related to dysregulation of blood flow.  I included the Keaton study as a well-powered, well-measured GWAS of a blood-flow related trait.
+- **Asthma** from the GWAS of Han et al.[@han2020genome]  Numerous authors have theorized a relationship between autonomic dysfunction, ME/CFS, and the activation of mast cells[@novak2022mast], but the evidence supporting these theories typically comes from small studies. I added asthma as a prototypical example of a common disease involving the IgE/ mast cell immune axis[^asthma_note].
+- Diastolic blood pressure (**DBP**) from the Keaton et al.[@keaton2024genome] It has been postulated that ME/CFS is related to dysregulation of blood flow[@van2020cerebral].  I included the Keaton study as a well-powered, well-measured GWAS of a blood-flow related trait.
 - **Educational attainment** from Lee et al[@lee2018gene], an example of an extremely complex trait with many determinants, some which lie in the central nervous system.
 - ME/CFS, from **DecodeME**[@genetics2025initial].
 - **Multi-site pain**, from Johnston et al.[@johnston2019genome] The DecodeME preprint reported colocalization between the ME/CFS signal and a multi-site chronic pain signal at a locus on chromosome 17.  I added multi-site pain to investigate whether there was evidence of genome-wide matching between pain and ME/CFS, in addition to localized matching.
 - **Inflammatory bowel disease** from Liu et al.[@liu2023genetic] Like asthma, IBD is an immunological disease, but it operates via a different subsystem of the immune system.  I was interested in observing how this contrast is reflected in genetic correlations.
-- **Schizophrenia** from the 2022 PGC study.[@trubetskoy2022mapping] Unlike certain other common complex diseases of the central nervous system, schizophrenia has a severe and relatively distinctive phenotype, which reduces the likelihood of diagnostic error.  In addition to involving genes active in neurons, genetic risk for schizophrenia appears to also be driven by the immunological genes ( see _"Identification of Genes for Schizophrenia Highlights the Interplay of Rare and Common Risk Variants_" in Chapter 1 of Kandel et al.[@kandel2021principles] and also the [S-LDSC analysis of schizophrenia](../../PGC_2022_(SCH)/S-LDSC_SCH_Analysis.md) in this repo).  It may thus be reasonable to describe schizophrenia as a neuroimmune condition. ME/CFS has also been called a neuroimmune condition, though the phenotypes of the two diseases are vastly different.
+- **Schizophrenia** from the 2022 PGC study[@trubetskoy2022mapping]. Unlike certain other common complex diseases of the central nervous system, schizophrenia has a severe and relatively distinctive phenotype, which reduces the likelihood of diagnostic error.  In addition to involving genes active in neurons, genetic risk for schizophrenia appears to also be driven by the immunological genes[^sch_note].  It may thus be reasonable to describe schizophrenia as a neuroimmune condition. ME/CFS has also been called a neuroimmune condition, though the phenotypes of the two diseases are vastly different.
 
 ## Comment on results
 
 - The trait most strongly genetically correlated with ME/CFS is multi-site pain. This is consistent with the [observation](https://www.s4me.info/threads/genome-wide-association-study-of-multisite-chronic-pain-in-uk-biobank-2019-johnston.44973/post-674317) that the Manhattan plots for DecodeME and multi-site pain appear to match closely at several loci.  This intriguing finding  deserves follow-up.
-- There are two other significant genetic correlations: with schizophrenia and with asthma.  As is often the case in genetic correlation studies, this finding is difficult to interpret. There are numerous possible theories.  For instance, the correlation between asthma and ME/CFS could reflect an IgE-related immune etiology, while the correlation between ME/CFS and Schizophrenia could reflect neurological etiology; or both correlations could reflect some common immune pathway. 
+- ME/CFS has two other significant genetic correlations: with schizophrenia and with asthma.  As is often the case in genetic correlation studies, these correlations are difficult to interpret. There are numerous possible theories.  For instance, the correlation between asthma and ME/CFS could reflect an IgE-related immune etiology, while the correlation between ME/CFS and Schizophrenia could reflect neurological etiology; or both correlations could reflect some common immune pathway. 
 
 ## Next steps
 
-Potential next steps:
-
 - Techniques like GenomicSEM[@grotzinger2019genomic], LCV[@o2018distinguishing], and MiXeR[@frei2019bivariate] may elucidate the causal structure of correlations discovered so far.
--  The inclusion of additional well-chosen phenotypes in the correlation study may shed light on existing traits through triangulation.
+-  The inclusion of additional well-chosen phenotypes in the correlation study may shed light through triangulation.
 
 ## Reproducing
 
 To reproduce these results, use [this script][mecfs_bio.analysis.ct_ldsc_analysis].
+
+
+[^sch_note]:  See _"Identification of Genes for Schizophrenia Highlights the Interplay of Rare and Common Risk Variants_" in Chapter 1 of Kandel et al.[@kandel2021principles] and also the [S-LDSC analysis of schizophrenia](../../PGC_2022_(SCH)/S-LDSC_SCH_Analysis.md) in this repo.
+
+[^asthma_note]: See _Janeway's Immunobiology,_[@murphy2022janeway] _Chapter 14: Allergic Diseases_.

--- a/docs/Bioinformatics_Concepts/Epigenetics.md
+++ b/docs/Bioinformatics_Concepts/Epigenetics.md
@@ -1,3 +1,4 @@
+# Epigenetics
 ## Introduction
 
 Neglecting somatic mutations, all non-gamete cells in the body contain the same DNA.  Despite this, the cells of multicellular organisms are diverse: adipocytes differ from neurons, which differ from macrophages, which differ from B cells, which differ from cardiomyocytes.

--- a/docs/Bioinformatics_Concepts/Heritability.md
+++ b/docs/Bioinformatics_Concepts/Heritability.md
@@ -99,12 +99,12 @@ Todo[@leia2025heritability]
 
 
 
-# Links
+## Links
 
 [Broad Institute Primer Talk on Heritability](https://www.youtube.com/watch?v=wM7yxJlvwe8)
 
 
-# References
+## References
 
 - Balding, David J., Ida Moltke, and John Marioni, eds. Handbook of statistical genomics. John Wiley & Sons, 2019. (Chapter 15)
 

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -691,3 +691,28 @@
   year={2018},
   publisher={Nature Publishing Group UK London}
 }
+
+
+@article{novak2022mast,
+  title={Mast cell disorders are associated with decreased cerebral blood flow and small fiber neuropathy},
+  author={Novak, Peter and Giannetti, Matthew P and Weller, Emily and Hamilton, Matthew J and Castells, Mariana},
+  journal={Annals of Allergy, Asthma \& Immunology},
+  volume={128},
+  number={3},
+  pages={299--306},
+  year={2022},
+  publisher={Elsevier},
+    url={https://www.sciencedirect.com/science/article/abs/pii/S1081120621011558}
+}
+
+
+@article{van2020cerebral,
+  title={Cerebral blood flow is reduced in ME/CFS during head-up tilt testing even in the absence of hypotension or tachycardia: A quantitative, controlled study using Doppler echography},
+  author={van Campen, C Linda MC and Verheugt, Freek WA and Rowe, Peter C and Visser, Frans C},
+  journal={Clinical Neurophysiology Practice},
+  volume={5},
+  pages={50--58},
+  year={2020},
+  publisher={Elsevier},
+    url={https://www.sciencedirect.com/science/article/pii/S2467981X20300044}
+}

--- a/mecfs_bio/build_system/task/magma/magma_gene_set_analysis_task.py
+++ b/mecfs_bio/build_system/task/magma/magma_gene_set_analysis_task.py
@@ -191,7 +191,7 @@ def _empty_gene_set_file(
     lim = (
         1 if (model_params is None or ~model_params.joint_pairs) else 2
     )  # the first column is the "GENE" column, so to have 1 gene set we need two columns, and to have two gene sets we need three
-    df = pd.read_csv(gene_set_file_path, sep="\s+")
+    df = pd.read_csv(gene_set_file_path, sep=r"\s+")
     if len(df.columns) <= lim:
         return True
     return False

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ theme:
     - content.footnote.tooltips
 plugins:
 - search
+- glightbox
 - bibtex:
     bib_file: "docs/refs.bib"
 - mkdocstrings:

--- a/pixi.lock
+++ b/pixi.lock
@@ -568,6 +568,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e6/ef/2a0971707b21f5490a557c9e1b0ac428d5d47e7ef604536d092ca186a28c/mkdocs_bibtex-4.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/0f/1e55b3fd490ad2cecb6e7b31892d27cb9fc4218ec1dab780440ba8579e74/mkdocs_gen_files-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9f/d4/029f984e8d3f3b6b726bd33cafc473b75e9e44c0f7e80a5b29abc466bdea/mkdocs_get_deps-0.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/4e/ca/03624e017e5ee2d7ce8a08d89f81c1e535eb3c30d7b2dc4a435ea3fbbeae/mkdocs_glightbox-0.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/84/b5b14d2745e4dd1a90115186284e9ee1b4d0863104011ab46abb7355a1c3/mkdocs_literate_nav-0.6.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3e/32/ed071cb721aca8c227718cffcf7bd539620e9799bbf2619e90c757bfd030/mkdocs_material-9.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl
@@ -668,6 +669,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/79/2e/415119c9ab3e62249e18c2b082c07aff907a273741b3f8160414b0e9193c/scipy-1.16.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ee/53/bc0ad50243638982c572894c9dd5205e690d34fda7ec6cadf1c1ce157e14/scipy_stubs-1.17.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f0/04/c3ae4a77e8cfa647b9177e727a7e80f64b160b65ad0db0dcb3738a4ef4a0/selectolax-0.4.6-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/a6/736a99c39baa85cf51922526525300fb732f2d31138c28ae1634370bf8bf/serializable-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/20/05/ed9b2571bbf38f1a2425391f18e3ac11cb1e91482c22d644a1640dea9da7/simplejson-3.20.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
@@ -1954,7 +1956,7 @@ packages:
 - pypi: ./
   name: biostatistics
   version: 0.1.0
-  sha256: fc3901f1a8a8bd3ac764c7d1446d45d1835a11d9378add903bbff0ab79938127
+  sha256: aeb467c86faefb53fedd15a3a8d633112b57b81f2266599e0baad08852ed63aa
   requires_python: ==3.12
   editable: true
 - pypi: https://files.pythonhosted.org/packages/7f/ad/ed66f7dd3d5e595a8bf1e115a54f77a185b616eb49ea94fe052c7fd4259e/blosc2-4.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
@@ -4978,6 +4980,13 @@ packages:
   - mergedeep>=1.3.4
   - platformdirs>=2.2.0
   - pyyaml>=5.1
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/4e/ca/03624e017e5ee2d7ce8a08d89f81c1e535eb3c30d7b2dc4a435ea3fbbeae/mkdocs_glightbox-0.5.2-py3-none-any.whl
+  name: mkdocs-glightbox
+  version: 0.5.2
+  sha256: 23a431ea802b60b1030c73323db2eed6ba859df1a0822ce575afa43e0ea3f47e
+  requires_dist:
+  - selectolax>=0.3.29
   requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/8a/84/b5b14d2745e4dd1a90115186284e9ee1b4d0863104011ab46abb7355a1c3/mkdocs_literate_nav-0.6.2-py3-none-any.whl
   name: mkdocs-literate-nav
@@ -9975,6 +9984,13 @@ packages:
   purls: []
   size: 228948
   timestamp: 1746562045847
+- pypi: https://files.pythonhosted.org/packages/f0/04/c3ae4a77e8cfa647b9177e727a7e80f64b160b65ad0db0dcb3738a4ef4a0/selectolax-0.4.6-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: selectolax
+  version: 0.4.6
+  sha256: c04fd180689ed9450ad2453a3cba74cff2475a4281f76db9e18a658b7823e594
+  requires_dist:
+  - cython ; extra == 'cython'
+  requires_python: '>=3.9,<3.15'
 - pypi: https://files.pythonhosted.org/packages/bd/a6/736a99c39baa85cf51922526525300fb732f2d31138c28ae1634370bf8bf/serializable-0.4.1-py3-none-any.whl
   name: serializable
   version: 0.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ analysis = [
     "seaborn>=0.13.2,<0.14",
     "textalloc>=1.2.1,<2",
     "types-seaborn>=0.13.2.20251221,<0.14",
- "rpy2>=3.6.4,<4", "uniprot-id-mapper>=1.1.4,<2", "forestplot>=0.4.1,<0.5", "zepid>=0.9.1,<0.10", "synapseclient>=4.11.0,<5", "import-linter>=2.9,<3", "pyreadr>=0.5.4,<0.6", "pygenometracks>=3.9,<4", "pybedtools>=0.12.0,<0.13", "tomli-w", "upsetplot>=0.9.0,<0.10", "pypng>=0.20220715.0,<0.20220716", ]
+ "rpy2>=3.6.4,<4", "uniprot-id-mapper>=1.1.4,<2", "forestplot>=0.4.1,<0.5", "zepid>=0.9.1,<0.10", "synapseclient>=4.11.0,<5", "import-linter>=2.9,<3", "pyreadr>=0.5.4,<0.6", "pygenometracks>=3.9,<4", "pybedtools>=0.12.0,<0.13", "tomli-w", "upsetplot>=0.9.0,<0.10", "pypng>=0.20220715.0,<0.20220716", "mkdocs-glightbox>=0.5.2,<0.6", ]
 
 ## pyproject.toml
 #[tool.pixi.pypi-options.dependency-overrides]

--- a/ruff.toml
+++ b/ruff.toml
@@ -28,7 +28,7 @@ exclude = [
     "venv",
 ]
 [lint]
-select= ["I","F401","F541","UP"]
+select= ["I","F401","F541","UP", "W605"]
 ignore =["UP007", "UP035"]
 [format]
 docstring-code-format = true


### PR DESCRIPTION
- Add the "lightbox" addon, which creates zoomable images.  I think this should partially help resolve the problem of small figure legends.  However, we should additionally try to make some changes to improve the readability of the figures (Like increasing legend font sizes). Closes #497 
- Edit the documentation of the genetic correlation study.  This involved rewording some descriptions and putting auxiliary information in footnotes.
- Use two hashes (`##`) instead of one hash (`#`) for subsections in some documentation files, to make sure subsections show up in the table of contents when it is displayed.
- Enable the ruff linting rule W605, which detects and fixes invalid string escape sequences.  Mkdocs was complaining about these escape sequences.