### PR TITLE
Fix capitalization in documentation references

### DIFF
--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -112,7 +112,7 @@
 }
 
 @book{grimmett2020probability,
-  title={Probability and random processes: third edition},
+  title={Probability and Random Processes: Third Edition},
   author={Grimmett, Geoffrey and Stirzaker, David},
   year={2001},
   publisher={Oxford university press},
@@ -120,7 +120,7 @@
 }
 
 @article{bernstein2010nih,
-  title={The {NIH} roadmap epigenomics mapping consortium},
+  title={The {NIH} {R}oadmap {E}pigenomics {M}apping {C}onsortium},
   author={Bernstein, Bradley E and Stamatoyannopoulos, John A and Costello, Joseph F and Ren, Bing and Milosavljevic, Aleksandar and Meissner, Alexander and Kellis, Manolis and Marra, Marco A and Beaudet, Arthur L and Ecker, Joseph R and others},
   journal={Nature Biotechnology},
   volume={28},


### PR DESCRIPTION
As described in issue #522, BibTeX requires placing brackets around letters that shouldn't be made lowercase no matter the citation style, so I've added brackets to letters in acronyms and proper nouns.