### PR TITLE
Slight fix to assumptions in LDSC derivation

### DIFF
--- a/docs/Bioinformatics_Concepts/LDSC.md
+++ b/docs/Bioinformatics_Concepts/LDSC.md
@@ -384,7 +384,7 @@ $$
 \begin{align}
 &\mathbb{Var}(X_{i,j})\\
 &= \mathbb{Var}( \mathbb{E}(X_{i,j}|f) ) + \mathbb{E}(  \mathbb{Var}(X_{i,j}|f)) & \text{ By law of total variance}\\
-&=0\\
+&=0+1\\
 &=1
 \end{align}
 $$


### PR DESCRIPTION
- I realized that in the derivation of mixed-population LDSC that I started to write up yesterday, the subpopulation genotypes cannot have the same variance as the mixed population genotypes.  This PR tweaks the assumptions to accommodate this. 
-  I plan to continue this derivation later.