### PR TITLE
Optionally Reduce Build output

### DIFF
--- a/mecfs_bio/build_system/runner/simple_runner.py
+++ b/mecfs_bio/build_system/runner/simple_runner.py
@@ -30,6 +30,7 @@ from mecfs_bio.build_system.rebuilder.verifying_trace_rebuilder.verifying_trace_
     VerifyingTraceRebuilder,
 )
 from mecfs_bio.build_system.scheduler.topological_scheduler import (
+    TopologicalSchedulerSettings,
     dependees_of_targets_from_tasks,
     topological,
 )
@@ -62,6 +63,7 @@ class SimpleRunner:
         targets: list[Task],
         must_rebuild_transitive: Sequence[Task] = tuple(),
         incremental_save: bool = True,
+        settings: TopologicalSchedulerSettings = TopologicalSchedulerSettings(),
     ) -> Mapping[AssetId, Asset]:
         """
         Targets: the ultimate targets we aim to produce.  All transitive dependencies of these targets will either be rebuilt, or fetched (determined according to that status of their trace)
@@ -96,6 +98,7 @@ class SimpleRunner:
             meta_to_path=meta_to_path,
             targets=[target.asset_id for target in targets],
             incremental_save_path=incremental_save_path,
+            settings=settings,
         )
         info.serialize(self.info_store)
         _print_target_locs(store, targets=targets)

--- a/mecfs_bio/build_system/scheduler/topological_scheduler.py
+++ b/mecfs_bio/build_system/scheduler/topological_scheduler.py
@@ -9,6 +9,7 @@ from typing import Mapping, Sequence
 import emoji
 import networkx as nx
 import structlog
+from attrs import frozen
 from loguru import logger
 
 logger = structlog.get_logger()
@@ -117,6 +118,19 @@ def _get_progress_list(todo: Sequence[AssetId], done: set[AssetId]) -> str:
     return s
 
 
+def _print_progress(
+    todo: Sequence[AssetId], done: set[AssetId], print_progress_list: bool
+):
+    if not print_progress_list:
+        return
+    logger.info(_get_progress_list(todo=todo, done=done))
+
+
+@frozen
+class TopologicalSchedulerSettings:
+    print_progress: bool = True
+
+
 def topological[
     Info,
 ](
@@ -127,6 +141,7 @@ def topological[
     info: Info,
     meta_to_path: MetaToPath,
     incremental_save_path: Path | None = None,
+    settings: TopologicalSchedulerSettings = TopologicalSchedulerSettings(),
 ) -> tuple[Mapping[AssetId, Asset], Info]:
     """
     A scheduler that builds a dependency graph of tasks, and executes them in topological order.
@@ -140,7 +155,11 @@ def topological[
     store: dict[AssetId, Asset] = {}
     frontier = _get_initial_frontier(G)
     while len(G) > 0:
-        logger.info(_get_progress_list(todo=todo, done=done))
+        _print_progress(
+            todo=todo,
+            done=done,
+            print_progress_list=settings.print_progress,
+        )
         node = frontier[0]
         task = tasks[node]
         maybe_asset = get_asset_if_exists(

--- a/mecfs_bio/figures/key_scripts/generate_figures.py
+++ b/mecfs_bio/figures/key_scripts/generate_figures.py
@@ -10,6 +10,9 @@ from mecfs_bio.build_system.meta.asset_id import AssetId
 from mecfs_bio.build_system.rebuilder.verifying_trace_rebuilder.tracer.imohash import (
     ImoHasher,
 )
+from mecfs_bio.build_system.scheduler.topological_scheduler import (
+    TopologicalSchedulerSettings,
+)
 from mecfs_bio.build_system.task.base_task import Task
 from mecfs_bio.figures.fig_constants import FIGURE_DIRECTORY
 from mecfs_bio.figures.figure_exporter import FigureExporter
@@ -19,7 +22,11 @@ _imo_hasher_128 = ImoHasher.with_xxhash_128()
 
 
 def _runner_func(tasks: Sequence[Task]) -> Mapping[AssetId, Asset]:
-    return DEFAULT_RUNNER.run(targets=list(tasks), incremental_save=True)
+    return DEFAULT_RUNNER.run(
+        targets=list(tasks),
+        incremental_save=True,
+        settings=TopologicalSchedulerSettings(print_progress=False),
+    )
 
 
 FIGURE_EXPORTER = FigureExporter(runner=_runner_func, tracer=_imo_hasher_128)


### PR DESCRIPTION
- Currently, the topological scheduler prints a list of all asset_ids in the current build graph after every step
- For small build graphs this is fine, but for large build graphs this can result in excessive printing to the terminal.
- To fix this, add the option to suppress this output to the topological scheduler.
- Use this option to disable printing in the topological scheduler used by the generate_figuers script, since it works with a rather large build graph.