### PR TITLE
Add Pipe For Float Formatting

### DIFF
--- a/experiments/tralfamadorian97/for_documentation/bivariate_mixer_table_gen.py
+++ b/experiments/tralfamadorian97/for_documentation/bivariate_mixer_table_gen.py
@@ -1,10 +1,16 @@
+from mecfs_bio.assets.gwas.me_cfs.decode_me.analysis.mixer.decode_me_univariate_mixer import DECODE_ME_UNIVARIATE_MIXER
 from mecfs_bio.assets.gwas.multi_trait.polygenic_overlap.bivariate_mixer.mecfs_pain_bivariate_mixer import \
     MECFS_PAIN_BIVARIATE_MIXER
+from mecfs_bio.assets.gwas.multisite_pain.johnston_et_al.analysis.mixer.johnston_et_al_univariate_mixer import \
+    JOHNSTON_ET_AL_UNIVARIATE_MIXER
 from mecfs_bio.figures.key_scripts.generate_figures import generate_figures
 
 
 def go():
-    generate_figures([MECFS_PAIN_BIVARIATE_MIXER.result_table_markdown_task])
+    generate_figures([MECFS_PAIN_BIVARIATE_MIXER.result_table_markdown_task,
+                      DECODE_ME_UNIVARIATE_MIXER.result_markdown_table_task,
+                      JOHNSTON_ET_AL_UNIVARIATE_MIXER.result_markdown_table_task
+                      ])
 
 
 if __name__ == '__main__':

--- a/experiments/tralfamadorian97/runs/mixer_runs.py
+++ b/experiments/tralfamadorian97/runs/mixer_runs.py
@@ -10,13 +10,15 @@ from mecfs_bio.build_system.scheduler.topological_scheduler import TopologicalSc
 
 def run_mixer():
     DEFAULT_RUNNER.run(
-        # [
-        # ]+DECODE_ME_UNIVARIATE_MIXER.terminal_tasks()
-        #  JOHNSTON_ET_AL_UNIVARIATE_MIXER.terminal_tasks(),
-        MECFS_PAIN_BIVARIATE_MIXER.terminal_tasks(),
+        [
+        ]+DECODE_ME_UNIVARIATE_MIXER.terminal_tasks()
+         +JOHNSTON_ET_AL_UNIVARIATE_MIXER.terminal_tasks()
+        +MECFS_PAIN_BIVARIATE_MIXER.terminal_tasks(),
         incremental_save=True,
         must_rebuild_transitive=[
-            MECFS_PAIN_BIVARIATE_MIXER.results
+            MECFS_PAIN_BIVARIATE_MIXER.results,
+            JOHNSTON_ET_AL_UNIVARIATE_MIXER.results_task,
+            DECODE_ME_UNIVARIATE_MIXER.results_task
             # DECODE_ME_UNIVARIATE_MIXER.combine_task
         ],
         settings=TopologicalSchedulerSettings(

--- a/mecfs_bio/asset_generator/mixer_asset_generator.py
+++ b/mecfs_bio/asset_generator/mixer_asset_generator.py
@@ -41,6 +41,7 @@ from mecfs_bio.build_system.task.mixer.mixer_univariate_results import (
 )
 from mecfs_bio.build_system.task.pipes.composite_pipe import CompositePipe
 from mecfs_bio.build_system.task.pipes.drop_col_pipe import DropColPipe
+from mecfs_bio.build_system.task.pipes.format_numbers_pipe import FormatFloatNumbersPipe
 from mecfs_bio.build_system.task.pipes.heritability_conversion_pipe import (
     HeritabilityConversionPipe,
 )
@@ -152,6 +153,7 @@ def univariate_mixer_asset_generator(
                     TransposePipe(),
                     RenameColByPositionPipe(col_position=0, col_new_name="Parameter"),
                     RenameColByPositionPipe(col_position=1, col_new_name="Value"),
+                    FormatFloatNumbersPipe(col="Value", format_str=".4g"),
                 ]
             ),
         )
@@ -254,6 +256,7 @@ def bivariate_mixer_asset_generator(
                     RenameColByPositionPipe(col_position=0, col_new_name="Parameter"),
                     RenameColByPositionPipe(col_position=1, col_new_name="Value"),
                     SelectColPipe(["Parameter", "Value"]),
+                    FormatFloatNumbersPipe(col="Value", format_str=".4g"),
                 ]
             ),
         )

--- a/mecfs_bio/build_system/task/pipes/format_numbers_pipe.py
+++ b/mecfs_bio/build_system/task/pipes/format_numbers_pipe.py
@@ -1,0 +1,37 @@
+"""
+Pipe to format a column of floating point values
+"""
+
+import narwhals
+from attrs import frozen
+
+from mecfs_bio.build_system.task.pipes.data_processing_pipe import DataProcessingPipe
+
+
+@frozen
+class FormatFloatNumbersPipe(DataProcessingPipe):
+    """
+    Pipe to set the format for floating point values in a given column.
+    """
+
+    format_str: str
+    col: str
+
+    def process(self, x: narwhals.LazyFrame) -> narwhals.LazyFrame:
+        collected = x.collect().to_pandas()
+        result_col = []
+        for value in collected[self.col].tolist():
+            if _convertible_to_float(value):
+                result_col.append(f"{float(value):{self.format_str}}")
+            else:
+                result_col.append(value)
+        collected[self.col] = result_col
+        return narwhals.from_native(collected).lazy()
+
+
+def _convertible_to_float(val: str) -> bool:
+    try:
+        float(val)
+        return True
+    except (ValueError, TypeError):
+        return False


### PR DESCRIPTION
- Problem: MiXeR reported results with too many significant digits.  Made the result tables feel cluttered.
- Solution: add a pipe to round a column to a given number of significant digits.  Use this pipe for MiXeR results.