### PR TITLE
Add checks for file existence when including files from docs 

### DIFF
--- a/docs/Analysis/DecodeME/Univariate_MiXeR_DecodeME.md
+++ b/docs/Analysis/DecodeME/Univariate_MiXeR_DecodeME.md
@@ -9,7 +9,7 @@ First, the table below lists the key MiXeR output parameters:
 
 
 
---8<-- "docs/_figs/decode_me_univariate_mixer_results_table_as_markdown.mdx"
+{{ include_file("docs/_figs/decode_me_univariate_mixer_results_table_as_markdown.mdx") }}
 
 By comparing $\pi \approx 0.0019$ to the values in Table 2 from the original MiXeR paper[@holland2020beyond],  we observe that ME/CFS is more polygenic than average.
 

--- a/docs/Analysis/Johnston_et_al_2019_(Pain)/5_Univeriate_MiXeR.md
+++ b/docs/Analysis/Johnston_et_al_2019_(Pain)/5_Univeriate_MiXeR.md
@@ -9,7 +9,7 @@ The table below lists the key MiXeR output parameters:
 
 
 
---8<-- "docs/_figs/johnston_et_al_pain_univariate_mixer_results_table_as_markdown.mdx"
+{{ include_file("docs/_figs/johnston_et_al_pain_univariate_mixer_results_table_as_markdown.mdx") }}
 
 
 A polygenicity score of $\pi \approx 0.004$ indicates a very polygenic trait.  A discoverability score of $\sigma^2_\beta \approx 8.85\times 10^{-6}$ indicates very small individual genetic effects.  Compared to ME/CFS, multisite pain appears to be determined by more genetic variants, each of which has a smaller genetic effect.

--- a/docs/Analysis/Kamitaki_et_al_2025_(HHV7)/MAGMA-HBA-Kamitaki.md
+++ b/docs/Analysis/Kamitaki_et_al_2025_(HHV7)/MAGMA-HBA-Kamitaki.md
@@ -16,7 +16,7 @@ The results are plotted below:
 I also used a conditional analysis approach based on the one described in Watanabe et al.[@watanabe2019genetic] to identify independent clusters. The two independent clusters are listed in the table below:
 
 
---8<-- "docs/_figs/kamitaki_et_al_2025_hhv7_hba_magma_independent_clusters_markdown.mdx"
+{{ include_file("docs/_figs/kamitaki_et_al_2025_hhv7_hba_magma_independent_clusters_markdown.mdx") }}
 
 
 HHV7 infections are highly prevalent.  As is the case with [EBV DNA levels](../Nyeo_et_al_2025_(EBV)/MAGMA-HBA-EBV.md), it is likely that HHV7 DNA levels are primarily a function of the extent to which a person's immune system is able to contain their infection, and maintain it in a dormant state.  For this reason, it makes sense that T-cells are a key cell type determining HHV7 DNA levels.

--- a/docs/Analysis/Multitrait/Polygenic_Overlap/Bivariate_Mixer/DecodeME_Multisite_Pain.md
+++ b/docs/Analysis/Multitrait/Polygenic_Overlap/Bivariate_Mixer/DecodeME_Multisite_Pain.md
@@ -8,7 +8,7 @@ In the [standard workflow suggested by authors](https://github.com/precimed/mixe
 The key output parameters from my bivariate MiXeR runs are shown below:
 
 
---8<--  "docs/_figs/initial_bivariate_mixer_DecodeME_Multisite_pain_bivariate_mixer_results_table_as_markdown.mdx"
+{{ include_file("docs/_figs/initial_bivariate_mixer_DecodeME_Multisite_pain_bivariate_mixer_results_table_as_markdown.mdx") }}
 
 The most important observation from these output parameters is that _best_vs_min_AIC_ and _best_vs_max_AIC_ are both slightly negative.  According to the [README provided by the authors](https://github.com/precimed/mixer/blob/master/README.md#aic-bic-interpretation)  this indicates that there is not strong statistical support for the full bivariate MiXeR model over simpler statistical models. I assume that this finding is a consequence of noise in the DecodeME summary statistics due to the relatively small sample size of the DecodeME study[^aic_training_note].
 

--- a/docs/Analysis/Verma_et_al_(LDL)/LDSC_LDL_Analysis.md
+++ b/docs/Analysis/Verma_et_al_(LDL)/LDSC_LDL_Analysis.md
@@ -5,7 +5,7 @@ I applied [Linkage Disequilibrium Score Regression](../../Bioinformatics_Concept
 
 The results are shown in the table below:
 
---8<--  "docs/_figs/million_veterans_ldl_ldsc_heritability_markdown.mdx"
+{{ include_file("docs/_figs/million_veterans_ldl_ldsc_heritability_markdown.mdx") }}
 
 
 The heritability of 0.1145 is low-to-moderate.  The LD score regression intercept of 1.586 is large, and indicates possible confounding or population stratification. This finding may be grounds to take any results that build on the Verma et al. summary statistics with a grain of salt.  At minimum, we should compare with other LDL GWAS.

--- a/docs/Analysis/Willer_et_al_2013_(Triglycerides)/LDSC_Wller_TG.md
+++ b/docs/Analysis/Willer_et_al_2013_(Triglycerides)/LDSC_Wller_TG.md
@@ -8,7 +8,7 @@ The results are below:
 
 
 
---8<--  "docs/_figs/willer_et_al_2023_tg_eur_ldsc_heritability_markdown.mdx"
+{{ include_file("docs/_figs/willer_et_al_2023_tg_eur_ldsc_heritability_markdown.mdx") }}
 
 The LDSC intercept of 1.014 suggests minimal evidence for population stratification.
 

--- a/docs/Analysis/Willler_et_al_2013_(LDL)/LDSC_Willer_LDL_Analysis.md
+++ b/docs/Analysis/Willler_et_al_2013_(LDL)/LDSC_Willer_LDL_Analysis.md
@@ -7,7 +7,7 @@ The results are below:
 
 
 
---8<--  "docs/_figs/willer_et_al_2023_ldl_eur_ldsc_heritability_markdown.mdx"
+{{ include_file("docs/_figs/willer_et_al_2023_ldl_eur_ldsc_heritability_markdown.mdx") }}
 
 
 In is interesting to contrast these results with those of the [Million Veterans Program GWAS of LDL](../Verma_et_al_(LDL)/LDSC_LDL_Analysis.md).  The most notable difference is in the LDSC intercept.  While the Million Veterans GWAS yields an LDSC intercept of 1.586, which strongly suggests population stratification or confounding, the Willer et al. GWAS yields an intercept of 0.9984, which does not suggest stratification or confounding. It is unclear exactly what explains this difference, but it does indicate that the Willer GWAS should be treated as more trustworthy than the Million Veterans GWAS.

--- a/docs/Analysis/Xue_et_al_2025_(Brainstem)/MAGMA-HBA-Xue.md
+++ b/docs/Analysis/Xue_et_al_2025_(Brainstem)/MAGMA-HBA-Xue.md
@@ -16,7 +16,7 @@ The results are plotted below:
 I also used a conditional analysis approach based on the one described in Watanabe et al.[@watanabe2019genetic] to identify independent clusters.  These clusters are shown in the table and plot below.
 
 
---8<-- "docs/_figs/xue_whole_brainstem_hba_magma_independent_clusters_markdown.mdx"
+{{ include_file("docs/_figs/xue_whole_brainstem_hba_magma_independent_clusters_markdown.mdx") }}
 
 
 ![xue_indep_cluster_plot](../../_figs/xue_whole_brainstem_hba_magma_independent_cluster_plot/hba_magma_fig.png)

--- a/main.py
+++ b/main.py
@@ -49,9 +49,7 @@ def define_env(env):
         """
         file_path = Path(path)
         if not file_path.is_file():
-            raise FileNotFoundError(
-                f"include_file: '{path}' does not exist"
-            )
+            raise FileNotFoundError(f"include_file: '{path}' does not exist")
         return file_path.read_text()
 
     @env.macro
@@ -74,6 +72,18 @@ def define_env(env):
             Supports inline HTML. When provided the whole embed is wrapped in
             a <figure> with width:100% so the iframe is never squished.
         """
+        # src is relative to the served page URL, which under use_directory_urls
+        # has an extra directory level (e.g. page.md -> page/index.html).
+        # Using dest_uri (which reflects the served path) to resolve correctly.
+        page_dir = Path(env.page.file.dest_uri).parent
+        docs_dir = Path(env.conf["docs_dir"])
+        resolved = (docs_dir / page_dir / src).resolve()
+        if not resolved.is_file():
+            raise FileNotFoundError(
+                f"plotly_embed: '{src}' resolved to '{resolved}' "
+                f"which does not exist (referenced from page '{env.page.file.src_uri}')"
+            )
+
         button = (
             f'<div style="display:flex; justify-content:flex-end; margin:.25rem 0;">\n'
             f"<button onclick=\"document.getElementById('{id}').requestFullscreen()\"\n"

--- a/main.py
+++ b/main.py
@@ -39,6 +39,22 @@ def define_env(env):
         return text
 
     @env.macro
+    def include_file(path):
+        """Include the contents of an external file, raising an error if it does not exist.
+
+        Parameters
+        ----------
+        path : str
+            Path to the file to include, relative to the project root.
+        """
+        file_path = Path(path)
+        if not file_path.is_file():
+            raise FileNotFoundError(
+                f"include_file: '{path}' does not exist"
+            )
+        return file_path.read_text()
+
+    @env.macro
     def plotly_embed(src, id, height="775px", caption=""):
         """
         This is a macro function added by Claude to allow the embedding of plotly plots which can be expanded to full screen.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,7 +28,8 @@ plugins:
         inventories:
           - https://docs.python.org/3/objects.inv
         options:
-          paths: [.]
+          extra:
+            paths: [.]
           docstring_section_style: list # or "table"
           docstring_style: "numpy"
           filters: [ "!^_" ]


### PR DESCRIPTION
- I have started making extensive use of text/file inclusion of markdown tables in my documentation.
- Problem: I have noticed that the mkdocs command I was using for this purpose had no error checking.  If the file to be included was missing, the command would fail silently without raising an error.  This allowed the generation of erroneous documentation.
- Solution: switch to using a custom macro that raises an error if the target file is missing.
- Also add a check to the plotly embed macro to check that the target file is present.