### PR TITLE
add pytest testmon to speed up `pixi r invoke green` locally

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -1980,7 +1980,7 @@ packages:
 - pypi: ./
   name: biostatistics
   version: 0.1.0
-  sha256: be7715b1a3d49a4a06722f694e01e44350cf88be17bee5beeff3303605cf60a2
+  sha256: e5541515d7eec30c015afa37d09fe9369f2a7227d4fcd1068fdb220137e88841
   requires_python: ==3.12
   editable: true
 - pypi: https://files.pythonhosted.org/packages/7f/ad/ed66f7dd3d5e595a8bf1e115a54f77a185b616eb49ea94fe052c7fd4259e/blosc2-4.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl

--- a/pixi.lock
+++ b/pixi.lock
@@ -494,6 +494,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cc/8f/ec6289987824b29529d0dfda0d74a07cec60e54b9c92f3c9da4c0ac732de/contourpy-1.3.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/0c/1a/0725a7037a69968ec3e6573f0bdc2fab1d9976c114618e2a2032ba0af66c/cooler-0.10.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/49/cd14b789536ac6a4778c453c6a2338bc0a2fb60c5a5a41b4008328b9acc1/coverage-7.13.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e1/93/c647bc3334355088c57351a536c2d4a83dd45f7de591fab383975e45bff9/cytoolz-1.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a4/2b/36b8753d881ff8fcf9c57eadd2b9379815cbe08fde7ded4e52c4cbb4b227/dask-2025.10.0-py3-none-any.whl
@@ -661,6 +662,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6d/2e/6277d370feebbe99f992ee3e409480e86715f34e52b5eb0383eddd1e5e7f/pyreadr-0.5.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/0c/fe/ce252dce8e5dd7ae06fd2036b5a146c1200598346ee70cbeb0a44740aa6b/pysam-0.22.1-cp312-cp312-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/61/55/ebb3c2f59fb089f08d00f764830d35780fc4e4c41dffcadafa3264682b65/pytest_testmon-2.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d4/69/31c82567719b34d8f6b41077732589104883771d182a9f4ff3e71430999a/python_utils-3.9.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl
@@ -1978,7 +1980,7 @@ packages:
 - pypi: ./
   name: biostatistics
   version: 0.1.0
-  sha256: 546888005fe431e70f5a261e9f507a348457098aef5b9ff9bbdcebfdf57d8408
+  sha256: be7715b1a3d49a4a06722f694e01e44350cf88be17bee5beeff3303605cf60a2
   requires_python: ==3.12
   editable: true
 - pypi: https://files.pythonhosted.org/packages/7f/ad/ed66f7dd3d5e595a8bf1e115a54f77a185b616eb49ea94fe052c7fd4259e/blosc2-4.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
@@ -2272,6 +2274,13 @@ packages:
   - pytest-cov ; extra == 'test'
   - ruff ; extra == 'test'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/8c/49/cd14b789536ac6a4778c453c6a2338bc0a2fb60c5a5a41b4008328b9acc1/coverage-7.13.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+  name: coverage
+  version: 7.13.5
+  sha256: 03ccc709a17a1de074fb1d11f217342fb0d2b1582ed544f554fc9fc3f07e95f5
+  requires_dist:
+  - tomli ; python_full_version <= '3.11' and extra == 'toml'
+  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.conda
   noarch: generic
   sha256: d3e9bbd7340199527f28bbacf947702368f31de60c433a16446767d3c6aaf6fe
@@ -6334,6 +6343,14 @@ packages:
   - setuptools ; extra == 'dev'
   - xmlschema ; extra == 'dev'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/61/55/ebb3c2f59fb089f08d00f764830d35780fc4e4c41dffcadafa3264682b65/pytest_testmon-2.2.0-py3-none-any.whl
+  name: pytest-testmon
+  version: 2.2.0
+  sha256: 2604ca44a54d61a2e830d9ce828b41a837075e4ebc1f81b148add8e90d34815b
+  requires_dist:
+  - pytest>=5,<10
+  - coverage>=6,<8
+  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.0-hab00c5b_0_cpython.conda
   sha256: 5398ebae6a1ccbfd3f76361eac75f3ac071527a8072627c4bf9008c689034f48
   md5: 7f97faab5bebcc2580f4f299285323da

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ analysis = [
     "mkdocs-glightbox>=0.5.2,<0.6",
     "mkdocs-macros-plugin>=1.3.0,<2",
     "frozendict>=2.4.7,<3",
-    "mkdocs-git-committers-plugin-2>=2.5.0,<3",
+    "mkdocs-git-committers-plugin-2>=2.5.0,<3", "pytest-testmon>=2.2.0,<3",
 ]
 
 ## pyproject.toml

--- a/tasks.py
+++ b/tasks.py
@@ -52,7 +52,9 @@ def _set_enable_api_autonav() -> None:
 # dev tasks
 @task
 def test(c):
-    print("Running unit and integration tests with pytest...")
+    print(
+        "Running unit and integration tests with pytest, while skipping un-needed tests with testmon..."
+    )
     cmd = f" python   -m pytest  --testmon --typeguard-packages={SRC_PATH}  {NEW_UNIT_TEST_PATH}"
     print(cmd)
     c.run(cmd, pty=True)

--- a/tasks.py
+++ b/tasks.py
@@ -53,7 +53,7 @@ def _set_enable_api_autonav() -> None:
 @task
 def test(c):
     print("Running unit and integration tests with pytest...")
-    cmd = f" python   -m pytest --typeguard-packages={SRC_PATH}  {NEW_UNIT_TEST_PATH}"
+    cmd = f" python   -m pytest  --testmon --typeguard-packages={SRC_PATH}  {NEW_UNIT_TEST_PATH}"
     print(cmd)
     c.run(cmd, pty=True)
 


### PR DESCRIPTION
- [pytest testmon](https://www.testmon.org/) uses the dependency graph of your tests to figure out which tests need to be rerun based on code changes.  It then reruns only those tests
- I have enabled testmon by default in `pixi r invoke green`, so that we can save time by not re-runing unneeded tests.
- Right now it will not have any effect in CI, since we do not cache the pytest testmon state.  But could  look into fixing this later.
- Related to #49 