### PR TITLE
cache testmon data in ci

### DIFF
--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -97,10 +97,15 @@ jobs:
         if: steps.changes.outputs.nonmark == 'true'
         uses: actions/cache@v4
         with:
-          path: .testmondata
-          key: testmon-v2-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'pixi.lock') }}-${{ steps.cache-date.outputs.date }}
+          # SQLite runs in WAL mode on CI; the actual data lives in .testmondata-wal
+          # until checkpointed, so we must cache the WAL/SHM sidecars too.
+          path: |
+            .testmondata
+            .testmondata-wal
+            .testmondata-shm
+          key: testmon-v3-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'pixi.lock') }}-${{ steps.cache-date.outputs.date }}
           restore-keys: |
-            testmon-v2-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'pixi.lock') }}-
+            testmon-v3-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'pixi.lock') }}-
       - name: Run tests
         if: steps.changes.outputs.nonmark == 'true'
         run: pixi r  invoke test # run unit and integration tests

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -98,9 +98,20 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .testmondata
-          key: testmon-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'pixi.lock') }}-${{ steps.cache-date.outputs.date }}
+          key: testmon-v2-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'pixi.lock') }}-${{ steps.cache-date.outputs.date }}
           restore-keys: |
-            testmon-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'pixi.lock') }}-
+            testmon-v2-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'pixi.lock') }}-
       - name: Run tests
         if: steps.changes.outputs.nonmark == 'true'
         run: pixi r  invoke test # run unit and integration tests
+      - name: Inspect testmon artifacts
+        if: always() && steps.changes.outputs.nonmark == 'true'
+        run: |
+          echo "github.workspace: ${{ github.workspace }}"
+          echo "PWD during this step: $(pwd)"
+          echo "--- workspace .testmondata* ---"
+          ls -la .testmondata* 2>/dev/null || echo "no .testmondata in workspace"
+          echo "--- find under /home/runner ---"
+          find /home/runner -name '.testmondata*' 2>/dev/null
+          echo "--- pixi shell view ---"
+          pixi r bash -c 'echo "pixi pwd: $(pwd)"; ls -la .testmondata* 2>/dev/null || echo "no .testmondata in pixi cwd"'

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -89,6 +89,18 @@ jobs:
       - name: Check types with ty
         if: steps.changes.outputs.nonmark == 'true'
         run: pixi r  invoke typecheck
+      - name: Compute cache date
+        if: steps.changes.outputs.nonmark == 'true'
+        id: cache-date
+        run: echo "date=$(date -u +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+      - name: Restore testmon cache # testmon cache can be used to skip tests if their dependencies have ot changed
+        if: steps.changes.outputs.nonmark == 'true'
+        uses: actions/cache@v4
+        with:
+          path: .testmondata
+          key: testmon-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'pixi.lock') }}-${{ steps.cache-date.outputs.date }}
+          restore-keys: |
+            testmon-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'pixi.lock') }}-
       - name: Run tests
         if: steps.changes.outputs.nonmark == 'true'
         run: pixi r  invoke test # run unit and integration tests

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -93,7 +93,7 @@ jobs:
         if: steps.changes.outputs.nonmark == 'true'
         id: cache-date
         run: echo "date=$(date -u +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
-      - name: Restore testmon cache # testmon cache can be used to skip tests if their dependencies have ot changed
+      - name: Restore testmon cache # testmon cache can be used to skip tests if their dependencies have not changed
         if: steps.changes.outputs.nonmark == 'true'
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
- Problem: we run all tests on every commit in CI, but most commits do not change the code covered by most tests, so most test runs are redundant.
- Solution: us testmon in CI to work out when to run tests by computing which tests are affected by which changes.
- testmon uses a sqllite database to cache test data.  We cache this database, together with its write-ahead-log between runs.
- Closes #49 