### PR TITLE
add testmondata to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -254,3 +254,8 @@ docs/_figs
 
 # config file for storing github token
 gh_token_config.yaml
+
+
+# testmon data
+
+.testmondata*


### PR DESCRIPTION
- testmon generates testmondata files.  We do not want to commit these files. 
- This PR adds them to .gitignore to prevent them from being committed 