### PR TITLE
Gene set analysis asset generator

### DIFF
--- a/experiments/tralfamadorian97/runs/miscl_runs.py
+++ b/experiments/tralfamadorian97/runs/miscl_runs.py
@@ -1,4 +1,8 @@
 from mecfs_bio.analysis.runner.default_runner import DEFAULT_RUNNER
+from mecfs_bio.assets.gwas.multisite_pain.johnston_et_al.analysis.johnston_standard_analysis import \
+    JOHNSTON_ET_AL_PAIN_STANDARD_ANALYSIS
+from mecfs_bio.assets.gwas.systemic_lupus_erythematosus.bentham_et_al_2015.analysis_results.bentham_2015_gene_sets import \
+    BENTHAM_2015_GENE_SET_ANALYSIS, BENTHAM_2015_GENE_SET_ANALYSIS_FROM_GENE_ANALYSIS
 from mecfs_bio.assets.reference_data.gene_set_data.for_magma.from_gsea_msigdb.processed.full_msigdb_parquet_from_sqlite import MSIGDB_GENE_SETS_PARQUET_FROM_SQLLITE
 
 from mecfs_bio.assets.reference_data.magma_specificity_matrices.processed.curated_potential_mecfs_gene_sets_specificity_matrix import \
@@ -23,8 +27,12 @@ def run_miscl_analysis():
             # YENGO_HEIGHT_STANDARD_ANALYSIS.heritability_markdown_task_unwrap
             # MILLION_VETERAN_MIGRAINE_EUR_DATA_RAW,
             # MILLION_VETERANS_EUR_MIGRAINE_STANDARD_ANALYSIS.get_terminal_tasks()
+        # BENTHAM_2015_GENE_SET_ANALYSIS.terminal_tasks()+
+        # BENTHAM_2015_GENE_SET_ANALYSIS_FROM_GENE_ANALYSIS.terminal_tasks()+
+        JOHNSTON_ET_AL_PAIN_STANDARD_ANALYSIS.gene_set_analysis_tasks.terminal_tasks()+
+
         [
-            CURATED_POTENTIAL_MECFS_GENE_SETS_SPECIFICITY_MATRIX_REDUCED
+            # CURATED_POTENTIAL_MECFS_GENE_SETS_SPECIFICITY_MATRIX_REDUCED
             # MSIGDB_GENE_SETS_PARQUET_FROM_SQLLITE,
             # MSIGDB_SQLLITE_EXTRACTED
             # MSIGDB_GENE_SETS_PARQUET_UNPACKED

--- a/mecfs_bio/asset_generator/concrete_standard_analysis_task_generator.py
+++ b/mecfs_bio/asset_generator/concrete_standard_analysis_task_generator.py
@@ -22,6 +22,10 @@ from mecfs_bio.asset_generator.labeled_lead_variants_asset_generator import (
     LabelLeadVariantsTasks,
     generate_tasks_labeled_lead_variants,
 )
+from mecfs_bio.asset_generator.magma_curated_gene_set_analysis_generator import (
+    CuratedGeneSetAnalysisTasks,
+    curated_gene_set_analysis_magma_tasks_from_gene_analysis,
+)
 from mecfs_bio.assets.reference_data.linkage_disequilibrium_score_reference_data.extracted.eur_ld_scores_thousand_genome_phase_3_v1_extracted import (
     THOUSAND_GENOME_EUR_LD_REFERENCE_DATA_V1_EXTRACTED,
 )
@@ -98,6 +102,7 @@ class StandardAnalysisTaskGroup:
     hba_magma_tasks: HBAMagmaTasks | None = None
     manhattan_task: Task | None = None
     heritability_task: Task | None = None
+    gene_set_analysis_tasks: CuratedGeneSetAnalysisTasks | None = None
 
     @property
     def hba_magma_tasks_unwrap(self) -> HBAMagmaTasks:
@@ -145,6 +150,7 @@ def concrete_standard_analysis_generator_assume_already_has_rsid(
     gget_settings: GGetSettings | None = GGetSettings(limit_genes=20),
     manhattan_settings: ManhattanPlotSettings | None = None,
     phenotype_info_for_ldsc: PhenotypeInfo | None = None,
+    include_gene_set_analysis: bool = True,
 ) -> StandardAnalysisTaskGroup:
     """
     Generate standard MAGMA and S-LDSC analysis tasks for given GWAS data,
@@ -252,6 +258,16 @@ def concrete_standard_analysis_generator_assume_already_has_rsid(
         )
     else:
         hba_magma = None
+    if include_gene_set_analysis:
+        assert include_hba_magma_tasks, (
+            "gene set analysis requires hba magma analysis, since the two analysis pathways make use of common MAGMA entrez gene analysis resulsts"
+        )
+        assert hba_magma is not None
+        gene_set_analysis = curated_gene_set_analysis_magma_tasks_from_gene_analysis(
+            base_name=base_name, gene_analysis_task=hba_magma.magma_gene_analysis_task
+        )
+    else:
+        gene_set_analysis = None
 
     return StandardAnalysisTaskGroup(
         sldsc_tasks=sldsc_tasks,
@@ -261,6 +277,7 @@ def concrete_standard_analysis_generator_assume_already_has_rsid(
         hba_magma_tasks=hba_magma,
         manhattan_task=manhattan_task,
         heritability_task=heritability_md_task,
+        gene_set_analysis_tasks=gene_set_analysis,
     )
 
 

--- a/mecfs_bio/asset_generator/magma_curated_gene_set_analysis_generator.py
+++ b/mecfs_bio/asset_generator/magma_curated_gene_set_analysis_generator.py
@@ -1,3 +1,7 @@
+"""
+Asset generator to perform gene set analysis using gene sets curated based on major theories of ME/CFS pathogensis
+"""
+
 from pathlib import PurePath
 
 from attrs import frozen

--- a/mecfs_bio/asset_generator/magma_curated_gene_set_analysis_generator.py
+++ b/mecfs_bio/asset_generator/magma_curated_gene_set_analysis_generator.py
@@ -1,1 +1,87 @@
+from pathlib import PurePath
 
+from mecfs_bio.assets.executable.extracted.magma_binary_extracted import MAGMA_1_1_BINARY_EXTRACTED
+from mecfs_bio.assets.reference_data.magma_gene_locations.processed.magma_entrez_gene_locations_data_build_37_unzipped import \
+    MAGMA_ENTREZ_GENE_LOCATION_REFERENCE_DATA_BUILD_37_EXTRACTED
+from mecfs_bio.assets.reference_data.magma_ld_reference.magma_eur_build_37_1k_genomes_ref_extracted import \
+    MAGMA_EUR_BUILD_37_1K_GENOMES_EXTRACTED
+from mecfs_bio.assets.reference_data.magma_specificity_matrices.processed.curated_potential_mecfs_gene_sets_specificity_matrix import \
+    CURATED_POTENTIAL_MECFS_GENE_SETS_SPECIFICITY_MATRIX
+from mecfs_bio.assets.reference_data.magma_specificity_matrices.processed.curated_potential_mecfs_gene_sets_specificity_matrix_reduced import \
+    CURATED_POTENTIAL_MECFS_GENE_SETS_SPECIFICITY_MATRIX_REDUCED
+from mecfs_bio.build_system.meta.read_spec.dataframe_read_spec import DataFrameReadSpec, \
+    DataFrameWhiteSpaceSepTextFormat
+from mecfs_bio.build_system.task.base_task import Task
+from mecfs_bio.build_system.task.copy_file_from_directory_task import CopyFileFromDirectoryTask
+from mecfs_bio.build_system.task.magma.magma_annotate_task import MagmaAnnotateTask
+from mecfs_bio.build_system.task.magma.magma_gene_analysis_task import MagmaGeneAnalysisTask
+from mecfs_bio.build_system.task.magma.magma_gene_set_analysis_task import MagmaGeneSetAnalysisTask, ModelParams, \
+    GENE_SET_ANALYSIS_OUTPUT_STEM_NAME
+from mecfs_bio.build_system.task.magma.magma_snp_location_task import MagmaSNPFileTask
+from mecfs_bio.build_system.task.pipes.data_processing_pipe import DataProcessingPipe
+
+
+def generate_curated_gene_set_analysis_magma_tasks(
+        base_name: str,
+        gwas_parquet_with_rsids_task: Task,
+        sample_size: int,
+        pipes: list[DataProcessingPipe] | None = None,
+):
+
+
+    magma_binary_task = MAGMA_1_1_BINARY_EXTRACTED
+    gene_loc_file_task = MAGMA_ENTREZ_GENE_LOCATION_REFERENCE_DATA_BUILD_37_EXTRACTED
+
+    p_value_task = MagmaSNPFileTask.create_for_magma_snp_p_value_file_compute_if_needed(
+        gwas_parquet_with_rsids_task=gwas_parquet_with_rsids_task,
+        asset_id=base_name + "_curated_gene_sets_magma_snp_p_values",
+        pipes=pipes,
+    )
+    snp_loc_task = MagmaSNPFileTask.create_for_magma_snp_pos_file(
+        gwas_parquet_with_rsids_task=gwas_parquet_with_rsids_task,
+        asset_id=base_name + "_curated_gene_sets_magma_snp_locs",
+        pipes=pipes,
+    )
+    annotations_task = MagmaAnnotateTask.create(
+        asset_id=base_name + "_curated_gene_sets_magma_annotations",
+        magma_binary_task=magma_binary_task,
+        snp_loc_file_task=snp_loc_task,
+        gene_loc_file_task=gene_loc_file_task,
+        window=(35, 10),  # This choice comes from the Duncan paper
+    )
+    gene_analysis_task = MagmaGeneAnalysisTask.create(
+        asset_id=base_name + "_curated_gene_sets_magma_gene_analysis",
+        magma_annotation_task=annotations_task,
+        magma_p_value_task=p_value_task,
+        magma_binary_task=magma_binary_task,
+        magma_ld_ref_task=MAGMA_EUR_BUILD_37_1K_GENOMES_EXTRACTED,
+        ld_ref_file_stem="g1000_eur",
+        sample_size=sample_size,
+    )
+    gene_set_analysis_task_full = MagmaGeneSetAnalysisTask.create(
+        asset_id=base_name + "_curated_gene_sets_full_gene_covar",
+        magma_gene_analysis_task=gene_analysis_task,
+        magma_binary_task=magma_binary_task,
+        gene_set_task=CURATED_POTENTIAL_MECFS_GENE_SETS_SPECIFICITY_MATRIX,
+        set_or_covar="covar",
+        model_params=ModelParams(direction_covar="greater", condition_hide=[]),
+    )
+
+
+    gene_set_analysis_task_reduced = MagmaGeneSetAnalysisTask.create(
+        asset_id=base_name + "_curated_gene_sets_reduced_gene_covar",
+        magma_gene_analysis_task=gene_analysis_task,
+        magma_binary_task=magma_binary_task,
+        gene_set_task=CURATED_POTENTIAL_MECFS_GENE_SETS_SPECIFICITY_MATRIX_REDUCED,
+        set_or_covar="covar",
+        model_params=ModelParams(direction_covar="greater", condition_hide=[]),
+    )
+    full_result_extraction_task = CopyFileFromDirectoryTask.create_result_table(
+        base_name + "_curated_gene_sets_full_covar_results_extracted",
+        source_directory_task=gene_set_analysis_task_full,
+        path_inside_directory=PurePath(
+            str(GENE_SET_ANALYSIS_OUTPUT_STEM_NAME + ".gsa.out")
+        ),
+        extension=".txt",
+        read_spec=DataFrameReadSpec(DataFrameWhiteSpaceSepTextFormat(comment_code="#")),
+    )

--- a/mecfs_bio/asset_generator/magma_curated_gene_set_analysis_generator.py
+++ b/mecfs_bio/asset_generator/magma_curated_gene_set_analysis_generator.py
@@ -1,34 +1,69 @@
 from pathlib import PurePath
 
-from mecfs_bio.assets.executable.extracted.magma_binary_extracted import MAGMA_1_1_BINARY_EXTRACTED
-from mecfs_bio.assets.reference_data.magma_gene_locations.processed.magma_entrez_gene_locations_data_build_37_unzipped import \
-    MAGMA_ENTREZ_GENE_LOCATION_REFERENCE_DATA_BUILD_37_EXTRACTED
-from mecfs_bio.assets.reference_data.magma_ld_reference.magma_eur_build_37_1k_genomes_ref_extracted import \
-    MAGMA_EUR_BUILD_37_1K_GENOMES_EXTRACTED
-from mecfs_bio.assets.reference_data.magma_specificity_matrices.processed.curated_potential_mecfs_gene_sets_specificity_matrix import \
-    CURATED_POTENTIAL_MECFS_GENE_SETS_SPECIFICITY_MATRIX
-from mecfs_bio.assets.reference_data.magma_specificity_matrices.processed.curated_potential_mecfs_gene_sets_specificity_matrix_reduced import \
-    CURATED_POTENTIAL_MECFS_GENE_SETS_SPECIFICITY_MATRIX_REDUCED
-from mecfs_bio.build_system.meta.read_spec.dataframe_read_spec import DataFrameReadSpec, \
-    DataFrameWhiteSpaceSepTextFormat
+from attrs import frozen
+
+from mecfs_bio.assets.executable.extracted.magma_binary_extracted import (
+    MAGMA_1_1_BINARY_EXTRACTED,
+)
+from mecfs_bio.assets.reference_data.magma_gene_locations.processed.magma_entrez_gene_locations_data_build_37_unzipped import (
+    MAGMA_ENTREZ_GENE_LOCATION_REFERENCE_DATA_BUILD_37_EXTRACTED,
+)
+from mecfs_bio.assets.reference_data.magma_ld_reference.magma_eur_build_37_1k_genomes_ref_extracted import (
+    MAGMA_EUR_BUILD_37_1K_GENOMES_EXTRACTED,
+)
+from mecfs_bio.assets.reference_data.magma_specificity_matrices.processed.curated_potential_mecfs_gene_sets_specificity_matrix import (
+    CURATED_POTENTIAL_MECFS_GENE_SETS_SPECIFICITY_MATRIX,
+)
+from mecfs_bio.assets.reference_data.magma_specificity_matrices.processed.curated_potential_mecfs_gene_sets_specificity_matrix_reduced import (
+    CURATED_POTENTIAL_MECFS_GENE_SETS_SPECIFICITY_MATRIX_REDUCED,
+)
+from mecfs_bio.build_system.meta.read_spec.dataframe_read_spec import (
+    DataFrameReadSpec,
+    DataFrameWhiteSpaceSepTextFormat,
+)
 from mecfs_bio.build_system.task.base_task import Task
-from mecfs_bio.build_system.task.copy_file_from_directory_task import CopyFileFromDirectoryTask
+from mecfs_bio.build_system.task.copy_file_from_directory_task import (
+    CopyFileFromDirectoryTask,
+)
 from mecfs_bio.build_system.task.magma.magma_annotate_task import MagmaAnnotateTask
-from mecfs_bio.build_system.task.magma.magma_gene_analysis_task import MagmaGeneAnalysisTask
-from mecfs_bio.build_system.task.magma.magma_gene_set_analysis_task import MagmaGeneSetAnalysisTask, ModelParams, \
-    GENE_SET_ANALYSIS_OUTPUT_STEM_NAME
+from mecfs_bio.build_system.task.magma.magma_gene_analysis_task import (
+    MagmaGeneAnalysisTask,
+)
+from mecfs_bio.build_system.task.magma.magma_gene_set_analysis_task import (
+    GENE_SET_ANALYSIS_OUTPUT_STEM_NAME,
+    MagmaGeneSetAnalysisTask,
+    ModelParams,
+)
+from mecfs_bio.build_system.task.magma.magma_plot_gene_set_result import (
+    MAGMAPlotGeneSetResult,
+)
 from mecfs_bio.build_system.task.magma.magma_snp_location_task import MagmaSNPFileTask
+from mecfs_bio.build_system.task.multiple_testing_table_task import (
+    MultipleTestingTableTask,
+)
 from mecfs_bio.build_system.task.pipes.data_processing_pipe import DataProcessingPipe
 
 
+@frozen
+class CuratedGeneSetAnalysisTasks:
+    gene_set_analysis_task_full: Task
+    full_result_extraction_task: Task
+    multiple_testing_task_full: Task
+    bar_plot_task_full: Task
+    gene_set_analysis_task_reduced: Task
+    multiple_testing_task_reduced: Task
+    bar_plot_task_reduced: Task
+
+    def terminal_tasks(self) -> list[Task]:
+        return [self.bar_plot_task_full, self.bar_plot_task_reduced]
+
+
 def generate_curated_gene_set_analysis_magma_tasks(
-        base_name: str,
-        gwas_parquet_with_rsids_task: Task,
-        sample_size: int,
-        pipes: list[DataProcessingPipe] | None = None,
-):
-
-
+    base_name: str,
+    gwas_parquet_with_rsids_task: Task,
+    sample_size: int,
+    pipes: list[DataProcessingPipe] | None = None,
+) -> CuratedGeneSetAnalysisTasks:
     magma_binary_task = MAGMA_1_1_BINARY_EXTRACTED
     gene_loc_file_task = MAGMA_ENTREZ_GENE_LOCATION_REFERENCE_DATA_BUILD_37_EXTRACTED
 
@@ -58,6 +93,18 @@ def generate_curated_gene_set_analysis_magma_tasks(
         ld_ref_file_stem="g1000_eur",
         sample_size=sample_size,
     )
+    return curated_gene_set_analysis_magma_tasks_from_gene_analysis(
+        base_name=base_name,
+        gene_analysis_task=gene_analysis_task,
+    )
+
+
+def curated_gene_set_analysis_magma_tasks_from_gene_analysis(
+    base_name: str,
+    gene_analysis_task: Task,
+) -> CuratedGeneSetAnalysisTasks:
+    magma_binary_task = MAGMA_1_1_BINARY_EXTRACTED
+
     gene_set_analysis_task_full = MagmaGeneSetAnalysisTask.create(
         asset_id=base_name + "_curated_gene_sets_full_gene_covar",
         magma_gene_analysis_task=gene_analysis_task,
@@ -66,7 +113,6 @@ def generate_curated_gene_set_analysis_magma_tasks(
         set_or_covar="covar",
         model_params=ModelParams(direction_covar="greater", condition_hide=[]),
     )
-
 
     gene_set_analysis_task_reduced = MagmaGeneSetAnalysisTask.create(
         asset_id=base_name + "_curated_gene_sets_reduced_gene_covar",
@@ -84,4 +130,57 @@ def generate_curated_gene_set_analysis_magma_tasks(
         ),
         extension=".txt",
         read_spec=DataFrameReadSpec(DataFrameWhiteSpaceSepTextFormat(comment_code="#")),
+    )
+
+    multiple_testing_task_full = MultipleTestingTableTask.create_from_result_table_task(
+        alpha=0.05,
+        source_task=full_result_extraction_task,
+        method="bonferroni",
+        asset_id=base_name + "_curated_gene_sets_full_multiple_testing",
+        p_value_column="P",
+        apply_filter=False,
+    )
+
+    bar_plot_task_full = MAGMAPlotGeneSetResult.create(
+        gene_set_analysis_task=gene_set_analysis_task_full,
+        asset_id=base_name + "_curated_gene_sets_full_magma_bar_plot",
+        number_of_bars=20,
+    )
+    ###
+
+    reduced_result_extraction_task = CopyFileFromDirectoryTask.create_result_table(
+        base_name + "_curated_gene_sets_reduced_covar_results_extracted",
+        source_directory_task=gene_set_analysis_task_reduced,
+        path_inside_directory=PurePath(
+            str(GENE_SET_ANALYSIS_OUTPUT_STEM_NAME + ".gsa.out")
+        ),
+        extension=".txt",
+        read_spec=DataFrameReadSpec(DataFrameWhiteSpaceSepTextFormat(comment_code="#")),
+    )
+
+    multiple_testing_task_reduced = (
+        MultipleTestingTableTask.create_from_result_table_task(
+            alpha=0.05,
+            source_task=reduced_result_extraction_task,
+            method="bonferroni",
+            asset_id=base_name + "_curated_gene_sets_reduced_multiple_testing",
+            p_value_column="P",
+            apply_filter=False,
+        )
+    )
+
+    bar_plot_task_reduced = MAGMAPlotGeneSetResult.create(
+        gene_set_analysis_task=gene_set_analysis_task_reduced,
+        asset_id=base_name + "_curated_gene_sets_reduced_magma_bar_plot",
+        number_of_bars=20,
+    )
+
+    return CuratedGeneSetAnalysisTasks(
+        gene_set_analysis_task_full=gene_set_analysis_task_full,
+        bar_plot_task_full=bar_plot_task_full,
+        multiple_testing_task_full=multiple_testing_task_full,
+        gene_set_analysis_task_reduced=gene_set_analysis_task_reduced,
+        full_result_extraction_task=full_result_extraction_task,
+        multiple_testing_task_reduced=multiple_testing_task_reduced,
+        bar_plot_task_reduced=bar_plot_task_reduced,
     )

--- a/mecfs_bio/assets/gwas/systemic_lupus_erythematosus/bentham_et_al_2015/analysis_results/bentham_2015_gene_sets.py
+++ b/mecfs_bio/assets/gwas/systemic_lupus_erythematosus/bentham_et_al_2015/analysis_results/bentham_2015_gene_sets.py
@@ -1,0 +1,17 @@
+from mecfs_bio.asset_generator.magma_curated_gene_set_analysis_generator import (
+    curated_gene_set_analysis_magma_tasks_from_gene_analysis,
+    generate_curated_gene_set_analysis_magma_tasks,
+)
+from mecfs_bio.assets.gwas.systemic_lupus_erythematosus.bentham_et_al_2015.analysis_results.bentham_2015_standard_analysis import (
+    BENTHAM_LUPUS_STANDARD_ANALYSIS,
+)
+
+BENTHAM_2015_GENE_SET_ANALYSIS = generate_curated_gene_set_analysis_magma_tasks(
+    base_name="betham_2015",
+    gwas_parquet_with_rsids_task=BENTHAM_LUPUS_STANDARD_ANALYSIS.magma_tasks.parquet_file_task,
+    sample_size=14267,
+)
+BENTHAM_2015_GENE_SET_ANALYSIS_FROM_GENE_ANALYSIS = curated_gene_set_analysis_magma_tasks_from_gene_analysis(
+    base_name="bentham_2015",
+    gene_analysis_task=BENTHAM_LUPUS_STANDARD_ANALYSIS.hba_magma_tasks_unwrap.magma_gene_analysis_task,
+)


### PR DESCRIPTION
- This PR adds an asset generator for applying gene set analysis to GWAS data using gene sets curated based on prevailing theories of ME/CFS pathogensis.
- There are two version of the analysis: one with the full list of gene sets and one on a smaller subset.  I regard the second analysis as exploratory.
- This new gene set analysis is added to the standard analysis asset generator.