### PR TITLE
document gene set findings

### DIFF
--- a/docs/Analysis/DecodeME/Curated_Gene_Set_Analysis_DecodeME.md
+++ b/docs/Analysis/DecodeME/Curated_Gene_Set_Analysis_DecodeME.md
@@ -2,7 +2,7 @@
 
 
 
-I aimed to run a [MAGMA](../../Bioinformatics_Concepts/MAGMA_Overview.md)-based[@de2015magma] competitive gene set analysis of DecodeME, but suspected that DecodeME would have insufficient statistical power for a fully-unbiased hypothesis-free study.  Therefor, I curated a list of about 50 gene sets from [MSigDB](https://www.gsea-msigdb.org/gsea/index.jsp) selected according to current leading theories of the pathogenesis of ME/CFS.  The list of curated gene sets can be found  {{ api_link("here", "mecfs_bio.constants.curated_gene_set_collections.curated_mecfs_gene_sets") }}. 
+I aimed to run a [MAGMA](../../Bioinformatics_Concepts/MAGMA_Overview.md)-based[@de2015magma] competitive gene set analysis of DecodeME, but suspected that DecodeME would have insufficient statistical power for a fully-unbiased hypothesis-free study.  Therefore, I curated a list of about 50 gene sets from [MSigDB](https://www.gsea-msigdb.org/gsea/index.jsp) selected according to current leading theories of the pathogenesis of ME/CFS.  The list of curated gene sets can be found  {{ api_link("here", "mecfs_bio.constants.curated_gene_set_collections.curated_mecfs_gene_sets") }}. 
 
 The results of MAGMA analysis using these curated gene sets are plotted below:
 
@@ -13,7 +13,7 @@ The results of MAGMA analysis using these curated gene sets are plotted below:
 
 
 
-Disappointingly, none of the gene sets meet the Bonferroni-corrected significance threshold. It is interesting to observe the T-cell receptor signalling gene set is the closetest to being significant.  This is consistent with T-cell-centric theories of ME/CFS pathogenesis[@edwardsproposed].
+Disappointingly, none of the gene sets meet the Bonferroni-corrected significance threshold. It is interesting to observe the T-cell receptor signalling gene set is the closest to being significant.  This is consistent with T-cell-centric theories of ME/CFS pathogenesis[@edwardsproposed].
 
 
 A reasonable next step might be to boost statistical power by pooling multiple studies.  Methods like GenomicSEM[@grotzinger2019genomic] could be used to combine DecodeME both with biobank GWAS of ME/CFS and with distinct but genetically correlated conditions (e.g. multisite pain[@johnston2019genome]).

--- a/docs/Analysis/DecodeME/Curated_Gene_Set_Analysis_DecodeME.md
+++ b/docs/Analysis/DecodeME/Curated_Gene_Set_Analysis_DecodeME.md
@@ -1,0 +1,19 @@
+# Curated Gene Set Analysis
+
+
+
+I aimed to run a [MAGMA](../../Bioinformatics_Concepts/MAGMA_Overview.md)-based[@de2015magma] competitive gene set analysis of DecodeME, but suspected that DecodeME would have insufficient statistical power for a fully-unbiased hypothesis-free study.  Therefor, I curated a list of about 50 gene sets from [MSigDB](https://www.gsea-msigdb.org/gsea/index.jsp) selected according to current leading theories of the pathogenesis of ME/CFS.  The list of curated gene sets can be found  {{ api_link("here", "mecfs_bio.constants.curated_gene_set_collections.curated_mecfs_gene_sets") }}. 
+
+The results of MAGMA analysis using these curated gene sets are plotted below:
+
+
+
+{{ plotly_embed("docs/_figs/decode_me_gsa_curated_gene_sets_full_magma_bar_plot/magma_gene_set_plot.html", id="DecodeME_Curated_Geneset")
+}}
+
+
+
+Disappointingly, none of the gene sets meet the Bonferroni-corrected significance threshold. It is interesting to observe the T-cell receptor signalling gene set is the closetest to being significant.  This is consistent with T-cell-centric theories of ME/CFS pathogenesis[@edwardsproposed].
+
+
+A reasonable next step might be to boost statistical power by pooling multiple studies.  Methods like GenomicSEM[@grotzinger2019genomic] could be used to combine DecodeME both with biobank GWAS of ME/CFS and with distinct but genetically correlated conditions (e.g. multisite pain[@johnston2019genome]).

--- a/docs/Bioinformatics_Concepts/MAGMA_Overview.md
+++ b/docs/Bioinformatics_Concepts/MAGMA_Overview.md
@@ -76,6 +76,8 @@ The null hypothesis $\beta_{j}= 0$ is tested.
 
 Rejecting this null would indicate that the degree to which the gene $i$ participates in the biological system $j$ is predictive of the extent of association of the gene with the phenotype, $Z_i$.  This would suggest that the biological system is related to the phenotype.
 
+
+
 ## Limitations
 
 While MAGMA is a very useful approach for detecting the key biological systems involved in a disease or trait, it has a number of limitations.  These include:
@@ -85,6 +87,10 @@ While MAGMA is a very useful approach for detecting the key biological systems i
 3. Relatedly, MAGMA relies on the assumption that if a biological system is important to a phenotype, the degree of participation of a gene in that biological system should be linearly related to the association of the gene with the phenotype.  While this is intuitively reasonable, it does not necessarily hold: biology is inherently nonlinear.
 4. Since MAGMA in its original form mostly uses proximity to associate genes with variants, it cannot incorporate long-distance regulatory effects.  If such effects are important to a disease, MAGMA could give misleading results.
 
+
+## Gene set analysis with MAGMA
+
+MAGMA can also be used for gene-set analysis, which is implemented as a special case of gene property analysis.  In perform gene set analysis, we simply set $E_{i,j}=1$ if gene $i$ is a member of gene set $j$, and 0 otherwise.
 
 ## References
 The above discussion is based on:

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -842,3 +842,11 @@
   publisher={Nature Publishing Group UK London},
     url={https://www.nature.com/articles/s41586-022-05275-y}
 }
+
+@article{edwardsproposed,
+  title={A Proposed Mechanism for ME/CFS Invoking Macrophage Fc$\gamma$RI and Interferon Gamma},
+  author={Edwards, Jonathan and Cambridge, Geraldine and Cliff, Jacqueline M},
+  journal = {Qeios},
+  year = {2025},
+  url={https://meassociation.org.uk/wp-content/uploads/2025/05/Proposed-Mechanism-for-MECFS-Invoking-Macrophage-Fc%CE%B3RI-and-Interferon-GammaEdwards-et-al-2025.pdf}
+}

--- a/experiments/tralfamadorian97/for_documentation/gene_set_gen.py
+++ b/experiments/tralfamadorian97/for_documentation/gene_set_gen.py
@@ -1,0 +1,14 @@
+from mecfs_bio.assets.gwas.me_cfs.decode_me.analysis.magma.decode_me_curated_gene_set_analysis import \
+    DECODE_ME_CURATED_GENE_SET_ANALYSIS
+from mecfs_bio.figures.key_scripts.generate_figures import generate_figures
+
+
+def go():
+    generate_figures([
+        DECODE_ME_CURATED_GENE_SET_ANALYSIS.bar_plot_task_full,
+    ])
+
+
+if __name__ == '__main__':
+    go()
+

--- a/experiments/tralfamadorian97/runs/miscl_runs.py
+++ b/experiments/tralfamadorian97/runs/miscl_runs.py
@@ -1,4 +1,6 @@
 from mecfs_bio.analysis.runner.default_runner import DEFAULT_RUNNER
+from mecfs_bio.assets.gwas.me_cfs.decode_me.analysis.magma.decode_me_curated_gene_set_analysis import \
+    DECODE_ME_CURATED_GENE_SET_ANALYSIS
 from mecfs_bio.assets.gwas.multisite_pain.johnston_et_al.analysis.johnston_standard_analysis import \
     JOHNSTON_ET_AL_PAIN_STANDARD_ANALYSIS
 from mecfs_bio.assets.gwas.systemic_lupus_erythematosus.bentham_et_al_2015.analysis_results.bentham_2015_gene_sets import \
@@ -29,8 +31,9 @@ def run_miscl_analysis():
             # MILLION_VETERANS_EUR_MIGRAINE_STANDARD_ANALYSIS.get_terminal_tasks()
         # BENTHAM_2015_GENE_SET_ANALYSIS.terminal_tasks()+
         # BENTHAM_2015_GENE_SET_ANALYSIS_FROM_GENE_ANALYSIS.terminal_tasks()+
-        JOHNSTON_ET_AL_PAIN_STANDARD_ANALYSIS.gene_set_analysis_tasks.terminal_tasks()+
+        # JOHNSTON_ET_AL_PAIN_STANDARD_ANALYSIS.gene_set_analysis_tasks.terminal_tasks()+
 
+        DECODE_ME_CURATED_GENE_SET_ANALYSIS.terminal_tasks()+
         [
             # CURATED_POTENTIAL_MECFS_GENE_SETS_SPECIFICITY_MATRIX_REDUCED
             # MSIGDB_GENE_SETS_PARQUET_FROM_SQLLITE,

--- a/mecfs_bio/assets/gwas/me_cfs/decode_me/analysis/magma/decode_me_curated_gene_set_analysis.py
+++ b/mecfs_bio/assets/gwas/me_cfs/decode_me/analysis/magma/decode_me_curated_gene_set_analysis.py
@@ -1,0 +1,13 @@
+from mecfs_bio.asset_generator.magma_curated_gene_set_analysis_generator import (
+    curated_gene_set_analysis_magma_tasks_from_gene_analysis,
+)
+from mecfs_bio.assets.gwas.me_cfs.decode_me.analysis.magma.decode_me_hba_magma_analysis import (
+    DECODE_ME_HBA_MAGMA_TASKS,
+)
+
+DECODE_ME_CURATED_GENE_SET_ANALYSIS = (
+    curated_gene_set_analysis_magma_tasks_from_gene_analysis(
+        base_name="decode_me_gsa",
+        gene_analysis_task=DECODE_ME_HBA_MAGMA_TASKS.magma_gene_analysis_task,
+    )
+)

--- a/mecfs_bio/figures/figure_task_list.py
+++ b/mecfs_bio/figures/figure_task_list.py
@@ -23,6 +23,9 @@ from mecfs_bio.assets.gwas.ldl.million_veterans.analysis.mv_ldl_heritability_tas
 from mecfs_bio.assets.gwas.ldl.willer_et_al.analysis.willer_ldl_standard_analysis import (
     WILLER_ET_AL_EUR_LDL_STANDARD_ANALYSIS,
 )
+from mecfs_bio.assets.gwas.me_cfs.decode_me.analysis.magma.decode_me_curated_gene_set_analysis import (
+    DECODE_ME_CURATED_GENE_SET_ANALYSIS,
+)
 from mecfs_bio.assets.gwas.me_cfs.decode_me.analysis.mixer.decode_me_univariate_mixer import (
     DECODE_ME_UNIVARIATE_MIXER,
 )
@@ -68,6 +71,7 @@ ALL_FIGURE_TASKS: list[Task] = [
     DECODE_ME_UNIVARIATE_MIXER.power_plot_task,
     DECODE_ME_UNIVARIATE_MIXER.qq_plot_task,
     DECODE_ME_UNIVARIATE_MIXER.result_markdown_table_task,
+    DECODE_ME_CURATED_GENE_SET_ANALYSIS.bar_plot_task_full,
     JOHNSTON_ET_AL_UNIVARIATE_MIXER.power_plot_task,
     JOHNSTON_ET_AL_UNIVARIATE_MIXER.qq_plot_task,
     JOHNSTON_ET_AL_UNIVARIATE_MIXER.result_markdown_table_task,


### PR DESCRIPTION
- Run MAGMA gene set analysis on DecodeME using gene sets curated based on leading theories of ME/CFS pathogeneisis. 
- Document the results.

- Unfortunately, there were no significant gene sets.  It is interesting that the gene set closest to significance was t-cell receptor signalling. It may be worthwhile to explore ways to boost power by pooling studies.
- Closes #639 