### PR TITLE
enable_automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+    "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,11 @@
   "extends": [
     "config:recommended"
   ],
-    "packageRules": [
+  "enabledManagers": [
+    "pixi",
+    "github-actions"
+  ],
+  "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],
       "matchCurrentVersion": "!/^0/",


### PR DESCRIPTION
- I am experimenting with using the renovate bot to update dependencies.  This PR enables auto merge for renovate, so that minor upgrades can be merged automatically.
- I also noticed that rennovate was failing because it was not upgrading the pixi.lock.  Claude suspected that this due to a race between two different upgrade engines.    This PR also explicitly sets the enabledManagers to use to avoid this.