### PR TITLE
Update pixi in ci

### DIFF
--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4
-      - uses: prefix-dev/setup-pixi@v0.9.2
+      - uses: prefix-dev/setup-pixi@v0.9.4
         name: Setup Pixi Environment
         with:
-          pixi-version: v0.55.0
+          pixi-version: v0.67.2
           cache: true
       - name: Download figures
         run: pixi r invoke pfig

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -25,10 +25,10 @@ jobs:
           path: ~/.cache
           restore-keys: |
             mkdocs-material-
-      - uses: prefix-dev/setup-pixi@v0.9.2
+      - uses: prefix-dev/setup-pixi@v0.9.4
         name: Setup Pixi Environment
         with:
-          pixi-version: v0.55.0
+          pixi-version: v0.67.2
           cache: true
       - run: pixi r invoke pfig
         name: Download figures

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -36,11 +36,11 @@ jobs:
         if: steps.changes.outputs.nonmark != 'true'
         run: |
           echo "Docs-only change; skipping tests/linters."
-      - uses: prefix-dev/setup-pixi@v0.9.2
+      - uses: prefix-dev/setup-pixi@v0.9.4
         name: Setup Pixi Environment
         if: steps.changes.outputs.nonmark == 'true'
         with:
-          pixi-version: v0.55.0
+          pixi-version: v0.67.2
           cache: true
       - name: Cache R Packages
         if: steps.changes.outputs.nonmark == 'true'

--- a/.github/workflows/system_test_decodeme.yml
+++ b/.github/workflows/system_test_decodeme.yml
@@ -26,10 +26,10 @@ jobs:
         with:
           remove-browsers: true
           verbose: true
-      - uses: prefix-dev/setup-pixi@v0.9.2
+      - uses: prefix-dev/setup-pixi@v0.9.4
         name: Setup Pixi Environment
         with:
-          pixi-version: v0.55.0
+          pixi-version: v0.67.2
           cache: true
       - name: Run lead variants integration test
         run: pixi r python -m pytest -s test_mecfs_bio/system/test_decode_me_initial_analysis.py # run lead variants integration test

--- a/.github/workflows/system_test_decodeme_hba_magma.yml
+++ b/.github/workflows/system_test_decodeme_hba_magma.yml
@@ -28,10 +28,10 @@ jobs:
         with:
           remove-browsers: true
           verbose: true
-      - uses: prefix-dev/setup-pixi@v0.9.2
+      - uses: prefix-dev/setup-pixi@v0.9.4
         name: Setup Pixi Environment
         with:
-          pixi-version: v0.55.0
+          pixi-version: v0.67.2
           cache: true
       - name: Run HBA-MAGMA integration test
         run: pixi r python -m pytest -s  test_mecfs_bio/system/test_decode_me_hba_magma.py   # run hba-magma on DecodeME data

--- a/.github/workflows/system_test_decodeme_s_ldsc.yml
+++ b/.github/workflows/system_test_decodeme_s_ldsc.yml
@@ -26,10 +26,10 @@ jobs:
         with:
           remove-browsers: true
           verbose: true
-      - uses: prefix-dev/setup-pixi@v0.9.2
+      - uses: prefix-dev/setup-pixi@v0.9.4
         name: Setup Pixi Environment
         with:
-          pixi-version: v0.55.0
+          pixi-version: v0.67.2
           cache: true
       - name: Run S-LSDC integration test
         run: pixi r python -m pytest -s  test_mecfs_bio/system/test_decode_me_s_ldsc.py  # run s-lsdc on DecodeME data

--- a/.github/workflows/system_test_harmonize.yml
+++ b/.github/workflows/system_test_harmonize.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4
-      - uses: prefix-dev/setup-pixi@v0.9.2
+      - uses: prefix-dev/setup-pixi@v0.9.4
         name: Setup Pixi Environment
         with:
-          pixi-version: v0.55.0
+          pixi-version: v0.67.2
           cache: true
       - name: Run harmonization integration test
         run: pixi r python -m pytest -s  test_mecfs_bio/system/test_harmonize_drop_ambiguous.py  # run harmonization on Decode-ME data

--- a/.github/workflows/system_test_lava.yml
+++ b/.github/workflows/system_test_lava.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4
-      - uses: prefix-dev/setup-pixi@v0.9.2
+      - uses: prefix-dev/setup-pixi@v0.9.4
         name: Setup Pixi Environment
         with:
-          pixi-version: v0.55.0
+          pixi-version: v0.67.2
           cache: true
       - name: Install R packages
         run: pixi r invoke install-r-packages

--- a/.github/workflows/system_test_mixer.yml
+++ b/.github/workflows/system_test_mixer.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4
-      - uses: prefix-dev/setup-pixi@v0.9.2
+      - uses: prefix-dev/setup-pixi@v0.9.4
         name: Setup Pixi Environment
         with:
-          pixi-version: v0.55.0
+          pixi-version: v0.67.2
           cache: true
       - name: Install R packages
         run: pixi r invoke install-r-packages

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+    "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,21 @@
     "pixi",
     "github-actions"
   ],
+  "constraints": {
+    "pixi": "0.67.2"
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^renovate\\.json$/"],
+      "matchStrings": [
+        "\"pixi\":\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "prefix-dev/pixi",
+      "extractVersionTemplate": "^v(?<version>.+)$"
+    }
+  ],
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,11 @@
   "extends": [
     "config:recommended"
   ],
-    "packageRules": [
+  "enabledManagers": [
+    "pixi",
+    "github-actions"
+  ],
+  "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],
       "matchCurrentVersion": "!/^0/",


### PR DESCRIPTION
- Renovate bot was failing due to a discrepancy in pixi versions.  This PR fixes this.