### PR TITLE
automerge_schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     "config:recommended"
   ],
   "minimumReleaseAge": "1 day",
-  "schedule": ["after 2am and before 5am"],
+  "automergeSchedule": ["after 2am and before 5am"],
   "prHourlyLimit": 1,
   "enabledManagers": [
     "pixi",


### PR DESCRIPTION
- Instead of scheduling when the bot can  run, schedule when it can create PRs.  This means we can see PRs get updated in real time as they adjust to changes on main, but we don't get overwhelmed with too many merges.