### PR TITLE
remove time restriction from renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,6 @@
     "config:recommended"
   ],
   "minimumReleaseAge": "1 day",
-  "automergeSchedule": ["after 2am and before 5am"],
   "prHourlyLimit": 1,
   "enabledManagers": [
     "pixi",


### PR DESCRIPTION
- For some reason, renovate bot is not auto-merging prs.  Remove time restriction to debug