### PR TITLE
dont_print_by_default

### DIFF
--- a/mecfs_bio/build_system/scheduler/topological_scheduler.py
+++ b/mecfs_bio/build_system/scheduler/topological_scheduler.py
@@ -128,7 +128,7 @@ def _print_progress(
 
 @frozen
 class TopologicalSchedulerSettings:
-    print_progress: bool = True
+    print_progress: bool = False
 
 
 def topological[


### PR DESCRIPTION
Printing the full list of tasks to execute after every task completion creates a lot of noise.  Disable this by default