### PR TITLE
Fix check links download current run

### DIFF
--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -55,6 +55,19 @@ jobs:
           workflow_conclusion: completed
       - name: Check links (streak-aware)
         run: pixi r invoke check-all-links-with-streak
+      - name: Print streak state
+        # Echo the state file into the run log so it can be inspected without
+        # downloading the artifact. dump_state already writes pretty-printed
+        # JSON. if: always() so the state is visible even when the streak
+        # task exits non-zero (URL crossed the threshold).
+        if: always()
+        run: |
+          if [ -f link_check_state.json ]; then
+            echo "=== link_check_state.json ==="
+            cat link_check_state.json
+          else
+            echo "link_check_state.json not present"
+          fi
       - name: Upload updated link-check streak state
         # always() ensures the streak file is persisted even when the workflow
         # fails because a URL has crossed the persistent-failure threshold.

--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -35,19 +35,24 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Download previous link-check streak state
-        # Fetch the streak state file written by the most recent run of this
-        # workflow. If no prior artifact exists yet (e.g. the very first run
-        # after this change) we silently proceed with an empty state.
+        # Fetch the streak state file written by the most recent prior run of
+        # this workflow. If no prior artifact exists yet (e.g. the very first
+        # run after this change) we silently proceed with an empty state.
         uses: dawidd6/action-download-artifact@v6
         with:
           workflow: check_links.yml
           name: link-check-state
           path: .
           if_no_artifact_found: warn
-          # Accept artifacts from any prior run, not just successful ones —
-          # we deliberately upload state even when the workflow fails so
-          # streaks keep counting across consecutive failing runs.
-          workflow_conclusion: ""
+          # `completed` filters on the run *status*, which is satisfied by any
+          # finished run regardless of conclusion (success, failure, cancelled,
+          # ...). This is what we want: the streak workflow intentionally fails
+          # when a URL crosses the threshold, but we still need to read state
+          # from those failing runs so streaks keep accumulating. We must NOT
+          # leave this as the empty string — that would cause dawidd6 to match
+          # the current in-progress run, whose upload step hasn't executed yet,
+          # so no artifact is ever found.
+          workflow_conclusion: completed
       - name: Check links (streak-aware)
         run: pixi r invoke check-all-links-with-streak
       - name: Upload updated link-check streak state


### PR DESCRIPTION
- There was a issue with a previous PR preventing the check_links workflow from correctly accumulating state.  This PR by Claude should fix the issue.