### PR TITLE
Minor fixes

### DIFF
--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -80,9 +80,9 @@ jobs:
       - name: Lint imports
         if: steps.changes.outputs.nonmark == 'true'
         run: pixi r invoke checkimports
-      - name: Check __init__.py files
-        if: steps.changes.outputs.nonmark == 'true'
-        run: pixi r invoke check-init-files
+#      - name: Check __init__.py files
+#        if: steps.changes.outputs.nonmark == 'true'
+#        run: pixi r invoke check-init-files
       - name: Check links
         if: steps.changes.outputs.nonmark == 'true'
         run: pixi r invoke check-local-links

--- a/mecfs_bio/build_system/task/gwaslab/gwaslab_genetic_corr_by_ct_ldsc_task.py
+++ b/mecfs_bio/build_system/task/gwaslab/gwaslab_genetic_corr_by_ct_ldsc_task.py
@@ -304,6 +304,11 @@ def load_and_preprocess_sumstats(
     sumstats_asset = fetch(source.asset_id)
     logger.debug(f"reading sumstats for {name}")
     sumstats = read_sumstats(sumstats_asset)
+    sumstats.infer_build()
+    if hasattr(
+        sumstats, "build"
+    ):  # added because it seems like the name of the build variable changed between gwaslab versions
+        sumstats._build = sumstats.build
     assert GWASLAB_RSID_COL in sumstats.data.columns
     sumstats.data = source.pipe.process_pandas(sumstats.data)
     filter_sumstats(sumstats, settings, build=build)

--- a/tasks.py
+++ b/tasks.py
@@ -406,7 +406,7 @@ def lint_actions(c):
         check_local_links,
         fix_table_trailing_newlines,
         checkimports,
-        fix_init_files,
+        # fix_init_files,
         typecheck,
         lint_actions,
         test,


### PR DESCRIPTION
- Disable init-files check and generation.  Problem is that if you create a new python package on a new git branch, commit it, and then change branched, the directory corresponding to that package still exists, and will be filled with an init file
- Seems GWASlab changed sumstats.build to sumstats._build between versions.  Add a patch to make my old sumstats backward compatible.