### PR TITLE
Speed up scheduler traversal of cached task graphs

### DIFF
--- a/mecfs_bio/build_system/rebuilder/base_rebuilder.py
+++ b/mecfs_bio/build_system/rebuilder/base_rebuilder.py
@@ -20,6 +20,10 @@ class Rebuilder[Info](ABC):
     - Decide whether a given asset is up-to-date using information from Info.
     - If the asset is up-to-date, return it together with Info.
     - If the asset is not up-to-date, bring it up-to-date, update Info, and return the new values of both.
+
+    The third element of the returned tuple is ``info_changed``: True iff this call
+    produced new state that needs to be persisted. The scheduler uses this to skip
+    incremental saves of Info when nothing changed (an all-cached run).
     """
 
     @abstractmethod
@@ -31,7 +35,7 @@ class Rebuilder[Info](ABC):
         wf: WF,
         info: Info,
         meta_to_path: MetaToPath,
-    ) -> tuple[Asset, Info]:
+    ) -> tuple[Asset, Info, bool]:
         pass
 
     @classmethod

--- a/mecfs_bio/build_system/rebuilder/verifying_trace_rebuilder/verifying_trace_rebuilder_core.py
+++ b/mecfs_bio/build_system/rebuilder/verifying_trace_rebuilder/verifying_trace_rebuilder_core.py
@@ -50,7 +50,7 @@ class VerifyingTraceRebuilder(Rebuilder[VerifyingTraceInfo]):
         wf: WF,
         info: VerifyingTraceInfo,
         meta_to_path: MetaToPath,
-    ) -> tuple[Asset, VerifyingTraceInfo]:
+    ) -> tuple[Asset, VerifyingTraceInfo, bool]:
         must_rebuild = task.asset_id in info.must_rebuild
 
         def fetch_trace(asset_id: AssetId) -> str:
@@ -68,7 +68,7 @@ class VerifyingTraceRebuilder(Rebuilder[VerifyingTraceInfo]):
                 logger.debug(
                     f"Successfully verified the trace of asset {task.asset_id}."
                 )
-                return asset, info
+                return asset, info, False
             logger.debug(f"Failed to verify the trace of asset {task.asset_id}.")
         logger.debug(f"Materializing asset {task.asset_id}....")
         new_value, deps = tracking_sandboxed_execute(
@@ -86,7 +86,7 @@ class VerifyingTraceRebuilder(Rebuilder[VerifyingTraceInfo]):
             new_value_trace=new_trace,
             deps_traced=deps_traced,
         )
-        return new_value, info
+        return new_value, info, True
 
     @classmethod
     def save_info(cls, info: VerifyingTraceInfo, path: Path):

--- a/mecfs_bio/build_system/scheduler/topological_scheduler.py
+++ b/mecfs_bio/build_system/scheduler/topological_scheduler.py
@@ -173,7 +173,7 @@ def topological[
             def __call__(self, asset_id: AssetId) -> Asset:
                 return store[asset_id]
 
-        new_asset, info = rebuilder.rebuild(
+        new_asset, info, info_changed = rebuilder.rebuild(
             task=task,
             asset=maybe_asset,
             fetch=SimpleFetch(),
@@ -181,7 +181,7 @@ def topological[
             info=info,
             meta_to_path=meta_to_path,
         )
-        if incremental_save_path is not None:
+        if incremental_save_path is not None and info_changed:
             rebuilder.save_info(info, incremental_save_path)
         store[node] = new_asset
         frontier, G = _update_frontier_and_G(G=G, completed=node, frontier=frontier)

--- a/mecfs_bio/util/file_io/atomic_write.py
+++ b/mecfs_bio/util/file_io/atomic_write.py
@@ -5,6 +5,10 @@ from typing import Any
 
 import yaml
 
+# Prefer the libyaml C dumper when available — typically ~6x faster than the
+# pure-Python SafeDumper, with identical output.
+_YAML_DUMPER = getattr(yaml, "CSafeDumper", yaml.SafeDumper)
+
 
 def atomic_write_yaml(
     path: str | Path,
@@ -48,6 +52,7 @@ def atomic_write_yaml(
                 sort_keys=sort_keys,
                 default_flow_style=False,
                 allow_unicode=True,
+                Dumper=_YAML_DUMPER,
             )
             f.write("\n")
             f.flush()


### PR DESCRIPTION
- Closes #750 
- Issue was actually rewriting the trace store even when nothing had changed. This PR fixes this by only rewriting the trace store when there is reason to do so.
