### PR TITLE
Fix latex typo

### DIFF
--- a/docs/Bioinformatics_Concepts/LDSC.md
+++ b/docs/Bioinformatics_Concepts/LDSC.md
@@ -665,7 +665,7 @@ It is more useful to consider the fraction of a typical $\chi^2$ statistic that 
 
 $$
 \begin{align}
-R:= \frac{\psi-1}{\chi^2_{text{mean}}-1}
+R:= \frac{\psi-1}{\chi^2_{\text{mean}}-1}
 \end{align}
 $$
 


### PR DESCRIPTION
This PR fixes a minor typo in the definition of the attenuation ratio.