### PR TITLE
Fix STATUS column handling for gwaslab v4 Int64 dtype

### DIFF
--- a/mecfs_bio/build_system/task/gwaslab/gwaslab_create_sumstats_task.py
+++ b/mecfs_bio/build_system/task/gwaslab/gwaslab_create_sumstats_task.py
@@ -140,17 +140,17 @@ def _do_harmonization(
         ref_infer=gl.get_path(options.ref_infer.name),
         ref_alt_freq=options.ref_infer.ref_alt_freq,
     )
+    # gwaslab v4+ stores STATUS as Int64; cast to string for character-level access
+    status_str = sumstats.data[GWASLAB_STATUS_COL].astype(str)
     if options.drop_missing_from_ref_seq:
         # see meaning of status codes here: https://cloufield.github.io/gwaslab/StatusCode/
-        missing_from_ref_seq = sumstats.data[GWASLAB_STATUS_COL].str[5:6] == "8"
+        missing_from_ref_seq = status_str.str[5:6] == "8"
         logger.debug(
             f"Dropping {missing_from_ref_seq.sum()} variants that are missing from the sequence FASTA reference"
         )
         sumstats.data = sumstats.data.loc[~missing_from_ref_seq, :]
     if options.drop_missing_from_ref_infer_or_ambiguous:
-        missing_from_ref_infer = (sumstats.data[GWASLAB_STATUS_COL].str[6] == "8") | (
-            sumstats.data[GWASLAB_STATUS_COL].str[6] == "7"
-        )
+        missing_from_ref_infer = (status_str.str[6] == "8") | (status_str.str[6] == "7")
         logger.debug(
             f"Dropping {missing_from_ref_infer.sum()} variants that are missing from the VCF reference"
         )
@@ -318,7 +318,7 @@ class GWASLabCreateSumstatsTask(Task):
 
 
 def _sumstats_raise_on_error(sumstats: gl.Sumstats):
-    error_status = sumstats.data[GWASLAB_STATUS_COL] == "9999999"
+    error_status = sumstats.data[GWASLAB_STATUS_COL].astype(str) == "9999999"
     if error_status.any():
         raise ValueError("GWASLAB Error")
     if len(sumstats.data) == 0:

--- a/test_mecfs_bio/unit/build_system/task/gwaslab/test_gwaslab_create_sumstats_task.py
+++ b/test_mecfs_bio/unit/build_system/task/gwaslab/test_gwaslab_create_sumstats_task.py
@@ -2,6 +2,7 @@ import pickle
 from pathlib import Path
 
 import gwaslab
+import pandas as pd
 
 from mecfs_bio.build_system.asset.base_asset import Asset
 from mecfs_bio.build_system.asset.file_asset import FileAsset
@@ -20,6 +21,7 @@ from mecfs_bio.build_system.task.gwaslab.gwaslab_sumstats_to_table_task import (
     GwasLabSumstatsToTableTask,
 )
 from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.constants.gwaslab_constants import GWASLAB_STATUS_COL
 
 
 def test_gwaslab_sumstats(
@@ -53,6 +55,11 @@ def test_gwaslab_sumstats(
             f,
         )
     assert isinstance(loaded, gwaslab.Sumstats)
+    assert loaded.data[GWASLAB_STATUS_COL].dtype == pd.Int64Dtype(), (
+        f"Expected gwaslab STATUS column to be Int64, got {loaded.data[GWASLAB_STATUS_COL].dtype}. "
+        "If gwaslab changed this dtype, update the STATUS column handling in "
+        "gwaslab_create_sumstats_task.py (_do_harmonization and _sumstats_raise_on_error)."
+    )
     scratch_loc_2 = tmp_path / "scratch_2"
     scratch_loc_2.mkdir(exist_ok=True, parents=True)
 


### PR DESCRIPTION
Fixed broken system test with Claude.

- in GWASLab version 4, the STATUS column is changes from str to int.  This broke some of the GWASLab-related Tasks.
- this PR fixes the issue.