### PR TITLE
Fix docs deployment

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -5,16 +5,17 @@ on:
       - master
       - main
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+concurrency:
+  group: pages
+  cancel-in-progress: false
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Configure Git Credentials
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
       - uses: actions/setup-python@v6
         with:
           python-version: 3.x
@@ -35,8 +36,20 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HAVE_GH_TOKEN: "True"
-      - run: pixi r mkdocs gh-deploy --force
+      - run: pixi r mkdocs build
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HAVE_GH_TOKEN: "True"
           ENABLE_API_AUTONAV: "True"
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # ME/CFS Biostatistics Home
 
-The ME/CFS Biostatistics repo is a home for reproducible, open-source analysis of biostatistical datasets pertaining to ME/CFS.
+Welcome.  The ME/CFS Biostatistics repo is a home for reproducible, open-source analysis of biostatistical datasets pertaining to ME/CFS.
 
 [//]: # (For full documentation visit [mkdocs.org]&#40;https://www.mkdocs.org&#41;.)
 


### PR DESCRIPTION
- I realized that using an old-fashioned approach to generate a site using github pages.  This approach commits html files to a branch, bloating the repo
- Claude suggested a modern, action-based deployment solution that avoids this issue.
- This PR implements this fix.
- Make a small modification to a documentation page so that I can see when the page has been deployed under the new system