### PR TITLE
exclude_index

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,8 @@ plugins:
     enabled: !ENV [HAVE_GH_TOKEN, false]
     token: !ENV [GH_TOKEN, "none"]
     branch: main
+    exclude:
+      [index.md]
     exclude_committers:
       - web-flow
 


### PR DESCRIPTION
- Don't show git committers for the index page of documentation