### PR TITLE
Make search for matching paths more precise.

### DIFF
--- a/mecfs_bio/figures/key_scripts/publish_figures.py
+++ b/mecfs_bio/figures/key_scripts/publish_figures.py
@@ -1,16 +1,21 @@
 """
 End-to-end "the figure system is out of date" workflow.
 
-Runs the three steps a contributor wants in sequence:
-  1. ``generate_new_figures`` --- invoke the build system for any figure
-     task in ALL_FIGURE_TASKS whose output is not yet on disk, and copy the
-     results into the figure directory.
-  2. ``prune_orphan_figures`` --- drop manifest entries (and local files)
+Runs the four steps a contributor wants in sequence:
+  1. ``pull_figures`` --- download any figures listed in the manifest
+     that are missing or out-of-date locally. This ensures that
+     ``generate_new_figures`` only triggers the build system for
+     genuinely new tasks, not for every figure the collaborator hasn't
+     pulled yet.
+  2. ``generate_new_figures`` --- invoke the build system for any figure
+     task in ALL_FIGURE_TASKS whose output is not yet on disk, and copy
+     the results into the figure directory.
+  3. ``prune_orphan_figures`` --- drop manifest entries (and local files)
      for figures no task in ALL_FIGURE_TASKS produces. If any such entry
      is still referenced in the documentation, the script raises before
      touching anything; the user resolves the conflict by restoring the
      task or removing the doc reference.
-  3. ``push_figures`` --- rehash the figure directory, update the
+  4. ``push_figures`` --- rehash the figure directory, update the
      committed manifest, and upload any new content-addressed blobs to
      the GitHub release.
 
@@ -28,6 +33,7 @@ from mecfs_bio.figures.fig_constants import (
 from mecfs_bio.figures.figure_task_list import ALL_FIGURE_TASKS
 from mecfs_bio.figures.key_scripts.generate_figures import FIGURE_EXPORTER
 from mecfs_bio.figures.key_scripts.generate_new_figures import generate_new_figures
+from mecfs_bio.figures.key_scripts.pull_figures import pull_figures
 from mecfs_bio.figures.key_scripts.push_figures import push_figures
 from mecfs_bio.figures.orphan_pruning import prune_orphan_figures
 
@@ -35,6 +41,8 @@ logger = structlog.get_logger()
 
 
 def publish_figures() -> None:
+    logger.info("Pulling existing figures from the GitHub release.")
+    pull_figures()
     logger.info("Generating any missing figures from ALL_FIGURE_TASKS.")
     generate_new_figures(
         all_figure_tasks=ALL_FIGURE_TASKS,

--- a/mecfs_bio/figures/orphan_pruning.py
+++ b/mecfs_bio/figures/orphan_pruning.py
@@ -30,24 +30,29 @@ class OrphanReferencedInDocsError(ValueError):
     """Raised when an orphan manifest path is still referenced by documentation."""
 
 
-def find_doc_references(rel_path: Path, docs_dir: Path) -> list[Path]:
+def find_doc_references(
+    rel_path: Path, docs_dir: Path, fig_dir_name: str
+) -> list[Path]:
     """
     Return every ``.md`` file under ``docs_dir`` whose contents mention
-    ``rel_path`` as a substring.
+    ``rel_path`` anchored to the figure directory name.
 
     Only ``.md`` files are scanned: ``.mdx`` files in this repo are
     figure tables, not documentation pages, and are included from inside
     ``.md`` files.
 
     The figure paths in the manifest are relative to the figure directory
-    (``docs/_figs``). Every reference style in the repo ---
+    (e.g. ``_figs``). Every reference style in the repo ---
     ``plotly_embed("docs/_figs/<rel_path>")``,
     ``include_file("docs/_figs/<rel_path>")``,
     ``![alt](../../_figs/<rel_path>)``, and
-    ``<iframe src="..._figs/<rel_path>">`` --- contains the rel_path
-    verbatim (POSIX form), so a substring search is reliable.
+    ``<iframe src="..._figs/<rel_path>">`` --- contains
+    ``<fig_dir_name>/<rel_path>`` as a substring, so searching for that
+    anchored form avoids false positives from bare filenames that happen
+    to appear inside longer paths (e.g. ``sldsc_scatter.html`` matching
+    ``some_prefix_s_ldsc_plot/sldsc_scatter.html``).
     """
-    needle = rel_path.as_posix()
+    needle = f"{fig_dir_name}/{rel_path.as_posix()}"
     hits: list[Path] = []
     for path in sorted(docs_dir.rglob("*")):
         if not path.is_file() or path.suffix not in _DOC_EXTENSIONS:
@@ -94,7 +99,9 @@ def prune_orphan_figures(
     blockers_missing: dict[Path, list[Path]] = {}
     safe_to_remove: list[Path] = []
     for rel_path in orphans:
-        refs = find_doc_references(rel_path=rel_path, docs_dir=docs_dir)
+        refs = find_doc_references(
+            rel_path=rel_path, docs_dir=docs_dir, fig_dir_name=fig_dir.name
+        )
         if refs:
             if (fig_dir / rel_path).exists():
                 blockers_present[rel_path] = refs

--- a/test_mecfs_bio/unit/figures/test_orphan_pruning.py
+++ b/test_mecfs_bio/unit/figures/test_orphan_pruning.py
@@ -37,27 +37,52 @@ def test_find_doc_references_picks_up_md(tmp_path: Path):
     (sub / "b.md").write_text('{{ plotly_embed("docs/_figs/my_plot.png", id="x") }}\n')
     (docs / "unrelated.md").write_text("nothing here\n")
 
-    hits = find_doc_references(rel_path=Path("my_plot.png"), docs_dir=docs)
+    hits = find_doc_references(
+        rel_path=Path("my_plot.png"), docs_dir=docs, fig_dir_name="_figs"
+    )
 
     assert sorted(hits) == sorted([docs / "a.md", sub / "b.md"])
 
 
-def test_find_doc_references_ignores_mdx_files(tmp_path: Path):
-    # .mdx files in this repo are figure tables, not documentation pages,
-    # so they should not gate orphan pruning.
+def test_find_doc_references_does_not_match_bare_filename_inside_longer_path(
+    tmp_path: Path,
+):
     docs = tmp_path / "docs"
     docs.mkdir()
-    (docs / "table.mdx").write_text("includes my_plot.png\n")
+    (docs / "page.md").write_text(
+        '{{ plotly_embed("docs/_figs/some_prefix_plot/inner.html", id="x") }}\n'
+    )
 
-    assert find_doc_references(rel_path=Path("my_plot.png"), docs_dir=docs) == []
+    hits = find_doc_references(
+        rel_path=Path("inner.html"), docs_dir=docs, fig_dir_name="_figs"
+    )
+    assert hits == []
+
+
+def test_find_doc_references_ignores_mdx_files(tmp_path: Path):
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "table.mdx").write_text("_figs/my_plot.png\n")
+
+    assert (
+        find_doc_references(
+            rel_path=Path("my_plot.png"), docs_dir=docs, fig_dir_name="_figs"
+        )
+        == []
+    )
 
 
 def test_find_doc_references_ignores_non_doc_files(tmp_path: Path):
     docs = tmp_path / "docs"
     docs.mkdir()
-    (docs / "notes.txt").write_text("references my_plot.png\n")
+    (docs / "notes.txt").write_text("_figs/my_plot.png\n")
 
-    assert find_doc_references(rel_path=Path("my_plot.png"), docs_dir=docs) == []
+    assert (
+        find_doc_references(
+            rel_path=Path("my_plot.png"), docs_dir=docs, fig_dir_name="_figs"
+        )
+        == []
+    )
 
 
 def test_find_doc_references_raises_on_non_utf8_doc(tmp_path: Path):
@@ -66,7 +91,9 @@ def test_find_doc_references_raises_on_non_utf8_doc(tmp_path: Path):
     (docs / "bad.md").write_bytes(b"\xff\xfe not utf8")
 
     with pytest.raises(UnicodeDecodeError):
-        find_doc_references(rel_path=Path("my_plot.png"), docs_dir=docs)
+        find_doc_references(
+            rel_path=Path("my_plot.png"), docs_dir=docs, fig_dir_name="_figs"
+        )
 
 
 def test_prune_drops_orphan_with_no_doc_reference_and_present_file(tmp_path: Path):


### PR DESCRIPTION
- Seems there was an imprecision in the logic to identify orphaned paths.  Basically, if there is  file with path A, and the documentation references path B, and path A is a sub-string of path B, the system will incorrectly conclude that the documentation references path A.
- This PR is a quick, dirty fix cooked up with Claude.  
- We could encounter this problem again. Should look for more permanent fix in the future.
- See #788 