### PR TITLE
Fix p-value filtering in gene-level manhattan plot

### DIFF
--- a/mecfs_bio/build_system/task/gene_manhattan_plot_task.py
+++ b/mecfs_bio/build_system/task/gene_manhattan_plot_task.py
@@ -94,6 +94,22 @@ _CANONICAL_CHROM_ORDER: list[str] = [str(i) for i in range(1, 23)] + ["X", "Y", 
 GeneIdKind = Literal["ensembl_id", "gene_name"]
 
 
+@frozen
+class GeneManhattanData:
+    """The genes to plot plus the multiple-testing count for the significance line.
+
+    df holds the rows to plot, after any max_p_value filtering.
+
+    num_genes_for_correction is the number of genes with a valid (positive,
+    non-null) p-value before max_p_value filtering. It drives the default
+    Bonferroni threshold so that the significance line stays invariant to the
+    purely visual max_p_value filter.
+    """
+
+    df: pd.DataFrame
+    num_genes_for_correction: int
+
+
 class GeneManhattanSource(ABC):
     """A source that yields rows of (chrom, pos, ensembl_id, gene_name, p) for a Manhattan plot."""
 
@@ -117,16 +133,54 @@ class GeneManhattanSource(ABC):
     @property
     @abstractmethod
     def genome_build(self) -> GenomeBuild:
-        """Genome build of the chromosomal positions exposed by ``load_df``.
+        """Genome build of the chromosomal positions exposed by load_df.
 
-        Drives the hover-text position label (``pos_hg19`` vs ``pos_hg38``).
+        Drives the hover-text position label (pos_hg19 vs pos_hg38).
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def max_p_value(self) -> float | None:
+        """Drop genes whose p-value is at or above this before plotting.
+
+        None disables filtering. Filtering is purely a visual simplification:
+        it does not affect the Bonferroni significance threshold, which is based
+        on the gene count before filtering.
         """
         pass
 
     @abstractmethod
-    def load_df(self, fetch: Fetch) -> pd.DataFrame:
-        """Materialize a pandas DataFrame with columns ``chrom``, ``pos``, ``ensembl_id``, ``gene_name``, ``p_value``."""
+    def _load_full_df(self, fetch: Fetch) -> pd.DataFrame:
+        """Materialize all candidate rows with columns chrom, pos, ensembl_id, gene_name, p_value.
+
+        Returns every gene the source knows about, with no max_p_value filtering
+        applied; the base load_df applies that filter and counts genes for the
+        multiple-testing correction.
+        """
         pass
+
+    def load_df(self, fetch: Fetch) -> GeneManhattanData:
+        """Load the full table, then apply the optional max_p_value filter.
+
+        The multiple-testing count is taken before filtering so that the
+        significance threshold is unaffected by max_p_value.
+        """
+        df = self._load_full_df(fetch)
+        valid_p = df[_P].notna() & (df[_P] > 0)
+        num_genes_for_correction = int(valid_p.sum())
+        if self.max_p_value is not None:
+            num_before = len(df)
+            df = df[df[_P] < self.max_p_value]
+            logger.info(
+                "Filtered genes by maximum p-value",
+                max_p_value=self.max_p_value,
+                num_dropped=num_before - len(df),
+                num_kept=len(df),
+            )
+        return GeneManhattanData(
+            df=df, num_genes_for_correction=num_genes_for_correction
+        )
 
 
 @frozen
@@ -137,11 +191,17 @@ class MagmaGeneSource(GeneManhattanSource):
     gene names are joined in from ``gene_thesaurus_task`` by Ensembl ID. When
     a gene is missing from the thesaurus, the Ensembl ID is used as the
     display name.
+
+    max_p_value, when not None, drops genes whose p-value is at or above it
+    before plotting, keeping the figure free of the many uninformative
+    high-p-value points. The default of 0.01 retains only the nominally
+    interesting tail. Filtering does not affect the significance threshold.
     """
 
     magma_task: Task
     gene_thesaurus_task: Task
     genome_build: GenomeBuild
+    max_p_value: float | None = 0.01
 
     @property
     def deps(self) -> list[Task]:
@@ -161,7 +221,7 @@ class MagmaGeneSource(GeneManhattanSource):
     def project(self) -> str:
         return self._magma_meta.project
 
-    def load_df(self, fetch: Fetch) -> pd.DataFrame:
+    def _load_full_df(self, fetch: Fetch) -> pd.DataFrame:
         magma_asset = fetch(self.magma_task.asset_id)
         assert isinstance(magma_asset, DirectoryAsset)
         magma_path = magma_asset.path / (GENE_ANALYSIS_OUTPUT_STEM_NAME + ".genes.out")
@@ -224,10 +284,10 @@ class GenePValueTableSource(GeneManhattanSource):
     Ensembl IDs (``"ensembl_id"``) join on the reference's Ensembl-ID column,
     gene symbols (``"gene_name"``) join on the reference's gene-name column.
 
-    max_p_value, when not None, drops genes whose p-value is greater than or
-    equal to it before plotting, keeping the figure free of the many
-    uninformative high-p-value points. The default of 0.01 retains only the
-    nominally interesting tail.
+    max_p_value, when not None, drops genes whose p-value is at or above it
+    before plotting, keeping the figure free of the many uninformative
+    high-p-value points. The default of 0.01 retains only the nominally
+    interesting tail. Filtering does not affect the significance threshold.
     """
 
     table_task: Task
@@ -256,7 +316,7 @@ class GenePValueTableSource(GeneManhattanSource):
     def project(self) -> str:
         return self._table_meta.project
 
-    def load_df(self, fetch: Fetch) -> pd.DataFrame:
+    def _load_full_df(self, fetch: Fetch) -> pd.DataFrame:
         join_col = _ENSEMBL_ID if self.gene_id_kind == "ensembl_id" else _GENE_NAME
 
         table_asset = fetch(self.table_task.asset_id)
@@ -271,16 +331,6 @@ class GenePValueTableSource(GeneManhattanSource):
                 _P: p_df[self.p_col].astype(float),
             }
         )
-
-        if self.max_p_value is not None:
-            num_before = len(p_df)
-            p_df = p_df[p_df[_P] < self.max_p_value]
-            logger.info(
-                "Filtered genes by maximum p-value",
-                max_p_value=self.max_p_value,
-                num_dropped=num_before - len(p_df),
-                num_kept=len(p_df),
-            )
 
         loc_asset = fetch(self.gene_locations_task.asset_id)
         loc_df = (
@@ -327,17 +377,21 @@ def build_manhattan_plot(
     sig_line_color: str,
     title: str | None,
     genome_build: GenomeBuild,
+    num_genes_for_correction: int | None = None,
 ) -> go.Figure:
     """Construct a Plotly figure containing a gene-level Manhattan plot.
 
-    Genes with non-positive or null p-values are dropped (``-log10`` is
-    undefined). If ``sig_threshold`` is ``None``, a Bonferroni-corrected
-    threshold ``0.05 / N_genes`` is used and a dashed horizontal line is drawn
-    at the corresponding ``-log10(p)``.
+    Genes with non-positive or null p-values are dropped (-log10 is undefined).
+    If sig_threshold is None, a Bonferroni-corrected threshold
+    0.05 / num_genes_for_correction is used and a dashed horizontal line is
+    drawn at the corresponding -log10(p). num_genes_for_correction should be the
+    number of genes tested, counted before any p-value filtering of df, so that
+    the threshold is invariant to such filtering; it falls back to the number of
+    plotted rows when not supplied.
 
-    ``genome_build`` selects the hover label for the gene's midpoint position
-    (``Position (hg19)`` for build 37, ``Position (hg38)`` for build 38).
-    Positions in ``df`` are assumed to already be in the declared build.
+    genome_build selects the hover label for the gene's midpoint position
+    (Position (hg19) for build 37, Position (hg38) for build 38). Positions in
+    df are assumed to already be in the declared build.
     """
     df = df.dropna(subset=[_P]).copy()
     df = df[df[_P] > 0]
@@ -367,7 +421,12 @@ def build_manhattan_plot(
     )
 
     if sig_threshold is None:
-        sig_threshold = 0.05 / len(df)
+        n_correction = (
+            num_genes_for_correction
+            if num_genes_for_correction is not None
+            else len(df)
+        )
+        sig_threshold = 0.05 / n_correction
     sig_y = float(-np.log10(sig_threshold))
 
     pos_label = f"position (hg{genome_build})"
@@ -453,15 +512,16 @@ class GeneManhattanPlotTask(Task):
         return self.source.deps
 
     def execute(self, scratch_dir: Path, fetch: Fetch, wf: WF) -> Asset:
-        df = self.source.load_df(fetch=fetch)
+        data = self.source.load_df(fetch=fetch)
         fig = build_manhattan_plot(
-            df=df,
+            df=data.df,
             sig_threshold=self.sig_threshold,
             point_size=self.point_size,
             colors=self.colors,
             sig_line_color=self.sig_line_color,
             title=self.title,
             genome_build=self.source.genome_build,
+            num_genes_for_correction=data.num_genes_for_correction,
         )
         out_path = scratch_dir / "gene_manhattan.html"
         fig.write_html(out_path, include_plotlyjs=self.plotly_js_mode)

--- a/mecfs_bio/build_system/task/gene_manhattan_plot_task.py
+++ b/mecfs_bio/build_system/task/gene_manhattan_plot_task.py
@@ -194,14 +194,14 @@ class MagmaGeneSource(GeneManhattanSource):
 
     max_p_value, when not None, drops genes whose p-value is at or above it
     before plotting, keeping the figure free of the many uninformative
-    high-p-value points. The default of 0.01 retains only the nominally
+    high-p-value points. The default of 0.1 retains only the nominally
     interesting tail. Filtering does not affect the significance threshold.
     """
 
     magma_task: Task
     gene_thesaurus_task: Task
     genome_build: GenomeBuild
-    max_p_value: float | None = 0.01
+    max_p_value: float | None = 0.1
 
     @property
     def deps(self) -> list[Task]:
@@ -286,7 +286,7 @@ class GenePValueTableSource(GeneManhattanSource):
 
     max_p_value, when not None, drops genes whose p-value is at or above it
     before plotting, keeping the figure free of the many uninformative
-    high-p-value points. The default of 0.01 retains only the nominally
+    high-p-value points. The default of 0.1 retains only the nominally
     interesting tail. Filtering does not affect the significance threshold.
     """
 
@@ -296,7 +296,7 @@ class GenePValueTableSource(GeneManhattanSource):
     p_col: str
     genome_build: GenomeBuild
     gene_id_kind: GeneIdKind = "ensembl_id"
-    max_p_value: float | None = 0.01
+    max_p_value: float | None = 0.1
 
     @property
     def deps(self) -> list[Task]:

--- a/test_mecfs_bio/unit/build_system/task/test_gene_manhattan_plot_task.py
+++ b/test_mecfs_bio/unit/build_system/task/test_gene_manhattan_plot_task.py
@@ -5,18 +5,24 @@ import pandas as pd
 import plotly.graph_objs as go
 import pytest
 
+from mecfs_bio.build_system.asset.directory_asset import DirectoryAsset
 from mecfs_bio.build_system.asset.file_asset import FileAsset
 from mecfs_bio.build_system.meta.asset_id import AssetId
 from mecfs_bio.build_system.meta.read_spec.dataframe_read_spec import (
     DataFrameParquetFormat,
     DataFrameReadSpec,
 )
+from mecfs_bio.build_system.meta.simple_directory_meta import SimpleDirectoryMeta
 from mecfs_bio.build_system.meta.simple_file_meta import SimpleFileMeta
 from mecfs_bio.build_system.rebuilder.fetch.base_fetch import Fetch
 from mecfs_bio.build_system.task.fake_task import FakeTask
 from mecfs_bio.build_system.task.gene_manhattan_plot_task import (
     GenePValueTableSource,
+    MagmaGeneSource,
     build_manhattan_plot,
+)
+from mecfs_bio.build_system.task.magma.magma_gene_analysis_task import (
+    GENE_ANALYSIS_OUTPUT_STEM_NAME,
 )
 
 
@@ -128,6 +134,33 @@ def test_build_manhattan_plot_default_sig_threshold_is_bonferroni():
     assert len(matching) == 1
 
 
+def test_build_manhattan_plot_bonferroni_uses_correction_count():
+    df = _synthetic_df()
+    # Supplying a correction count larger than the plotted-row count (e.g. because
+    # high-p-value genes were filtered out before plotting) must drive the
+    # threshold, keeping the significance line invariant to that filtering.
+    num_genes_for_correction = 5_000
+    fig = build_manhattan_plot(
+        df=df,
+        sig_threshold=None,
+        point_size=5,
+        colors=("#1f77b4", "#ff7f0e"),
+        sig_line_color="red",
+        title=None,
+        genome_build="19",
+        num_genes_for_correction=num_genes_for_correction,
+    )
+
+    expected_y = float(-np.log10(0.05 / num_genes_for_correction))
+    shapes = fig.layout.shapes
+    matching = [
+        s
+        for s in shapes
+        if np.isclose(float(s.y0), expected_y) and np.isclose(float(s.y1), expected_y)
+    ]
+    assert len(matching) == 1
+
+
 def test_build_manhattan_plot_drops_nonpositive_and_null_pvalues():
     df = _synthetic_df()
     # Inject a row with p == 0 and a row with p == NaN. Both should be dropped
@@ -220,15 +253,89 @@ def _write_gene_pvalue_source(
 
 def test_gene_pvalue_source_filters_by_max_p_value(tmp_path: Path):
     source, fetch = _write_gene_pvalue_source(tmp_path, max_p_value=0.01)
-    df = source.load_df(fetch=fetch)
+    data = source.load_df(fetch=fetch)
     # 0.5 and 0.02 are at or above 0.01 and dropped; 1e-3 and 1e-9 remain.
-    assert sorted(df["p_value"].tolist()) == [1e-9, 1e-3]
+    assert sorted(data.df["p_value"].tolist()) == [1e-9, 1e-3]
 
 
 def test_gene_pvalue_source_no_filter_when_max_p_value_none(tmp_path: Path):
     source, fetch = _write_gene_pvalue_source(tmp_path, max_p_value=None)
-    df = source.load_df(fetch=fetch)
-    assert len(df) == 4
+    data = source.load_df(fetch=fetch)
+    assert len(data.df) == 4
+
+
+def test_gene_pvalue_source_correction_count_is_pre_filter(tmp_path: Path):
+    # All four genes have valid positive p-values, so the multiple-testing count
+    # must be 4 regardless of how many rows survive the max_p_value filter.
+    source, fetch = _write_gene_pvalue_source(tmp_path, max_p_value=0.01)
+    data = source.load_df(fetch=fetch)
+    assert len(data.df) == 2
+    assert data.num_genes_for_correction == 4
+
+
+def _write_magma_source(
+    tmp_path: Path,
+    max_p_value: float | None,
+) -> tuple[MagmaGeneSource, Fetch]:
+    """Build a MagmaGeneSource over four genes with p-values 0.5, 0.02, 1e-3, 1e-9.
+
+    Returns the source plus a fetch callable that resolves its two task assets.
+    """
+    magma_dir = tmp_path / "magma"
+    magma_dir.mkdir()
+    genes_out = magma_dir / f"{GENE_ANALYSIS_OUTPUT_STEM_NAME}.genes.out"
+    genes_out.write_text(
+        "GENE CHR START STOP P\n"
+        "ENSG000 1 100000 150000 0.5\n"
+        "ENSG001 1 200000 250000 0.02\n"
+        "ENSG002 2 100000 150000 1e-3\n"
+        "ENSG003 X 100000 150000 1e-9\n"
+    )
+
+    thesaurus_df = pd.DataFrame(
+        {
+            "Gene stable ID": ["ENSG000", "ENSG001", "ENSG002", "ENSG003"],
+            "Gene name": ["GENE0", "GENE1", "GENE2", "GENE3"],
+        }
+    )
+    thesaurus_path = tmp_path / "thesaurus.parquet"
+    thesaurus_df.to_parquet(thesaurus_path)
+
+    source = MagmaGeneSource(
+        magma_task=FakeTask(SimpleDirectoryMeta("magma")),
+        gene_thesaurus_task=FakeTask(
+            SimpleFileMeta(
+                "thesaurus", read_spec=DataFrameReadSpec(DataFrameParquetFormat())
+            )
+        ),
+        genome_build="19",
+        max_p_value=max_p_value,
+    )
+
+    def fetch(asset_id: AssetId):
+        if asset_id == "magma":
+            return DirectoryAsset(magma_dir)
+        if asset_id == "thesaurus":
+            return FileAsset(thesaurus_path)
+        raise ValueError(f"Unknown asset id {asset_id}")
+
+    return source, fetch
+
+
+def test_magma_source_filters_by_max_p_value(tmp_path: Path):
+    source, fetch = _write_magma_source(tmp_path, max_p_value=0.01)
+    data = source.load_df(fetch=fetch)
+    # 0.5 and 0.02 are at or above 0.01 and dropped; 1e-3 and 1e-9 remain. The
+    # correction count still reflects all four tested genes.
+    assert sorted(data.df["p_value"].tolist()) == [1e-9, 1e-3]
+    assert data.num_genes_for_correction == 4
+
+
+def test_magma_source_no_filter_when_max_p_value_none(tmp_path: Path):
+    source, fetch = _write_magma_source(tmp_path, max_p_value=None)
+    data = source.load_df(fetch=fetch)
+    assert len(data.df) == 4
+    assert data.num_genes_for_correction == 4
 
 
 def test_build_manhattan_plot_empty_df_raises():


### PR DESCRIPTION
- Realized that Claude introduced a bug in the gene-level Manhattan plot task an earlier PR: the Bonferoni-corrected p-value threshold was based on the number genes plotted, not the number of genes testes.
- This PR fixes this bug.