### PR TITLE
In forward stepwise analysis of MAGMA results, handle the case in which there is only one significant cluster

### DIFF
--- a/mecfs_bio/build_system/task/magma/magma_forward_stepwise_select_task.py
+++ b/mecfs_bio/build_system/task/magma/magma_forward_stepwise_select_task.py
@@ -81,6 +81,24 @@ class MagmaForwardStepwiseSelectTask(Task):
         )
         df_marg = pd.read_csv(marginal_path, comment="#", sep=r"\s+")
         df_cond = pd.read_csv(conditional_path, comment="#", sep=r"\s+")
+
+        sig_cluster_list = get_sig_cluster_list(
+            df_marg=df_marg, significance_threshold=self.significance_threshold
+        )
+
+        if len(sig_cluster_list) == 1:
+            logger.debug(
+                f"Only one significant cluster found ({sig_cluster_list}).  Skipping conditional analysis and returning this cluster"
+            )
+            retained_cluster_df = pd.DataFrame(
+                {
+                    RETAINED_CLUSTERS_COLUMN: sig_cluster_list,
+                }
+            )
+            out_path = scratch_dir / self.asset_id
+            retained_cluster_df.to_csv(out_path, index=False)
+            return FileAsset(out_path)
+
         if (len(df_marg) == 0) or (len(df_cond) == 0):
             logger.debug(
                 f"Marginal DF has {len(df_marg)} rows, while conditional df has {len(df_cond)} rows.  Cannot perform stepwise analysis. Skipping"
@@ -99,18 +117,6 @@ class MagmaForwardStepwiseSelectTask(Task):
         p_marg_dict, prop_sig_dict = generate_mappers_from_wide_dataframe(
             df_wide=df_wide
         )
-
-        all_cluster_list = df_marg.sort_values(by=MAGMA_P_COLUMN)[
-            MAGMA_VARIABLE_COLUMN
-        ].tolist()
-        sig_cluster_set = set(
-            df_marg.loc[
-                df_marg[MAGMA_P_COLUMN] <= (self.significance_threshold / len(df_marg))
-            ][MAGMA_VARIABLE_COLUMN].tolist()
-        )
-        sig_cluster_list = [
-            item for item in all_cluster_list if item in sig_cluster_set
-        ]
 
         retained_cluster_list = get_retained_clusters(
             all_cluster_list=sig_cluster_list,
@@ -239,6 +245,23 @@ def generate_wide_dataframe(
 
     assert (df_wide["P_MARG_a"] <= df_wide["P_MARG_b"]).all()
     return df_wide
+
+
+def get_sig_cluster_list(
+    df_marg: pd.DataFrame, significance_threshold: float
+) -> list[str]:
+    if len(df_marg) == 0:
+        return []
+    all_cluster_list = df_marg.sort_values(by=MAGMA_P_COLUMN)[
+        MAGMA_VARIABLE_COLUMN
+    ].tolist()
+    sig_cluster_set = set(
+        df_marg.loc[df_marg[MAGMA_P_COLUMN] <= (significance_threshold / len(df_marg))][
+            MAGMA_VARIABLE_COLUMN
+        ].tolist()
+    )
+    sig_cluster_list = [item for item in all_cluster_list if item in sig_cluster_set]
+    return sig_cluster_list
 
 
 def generate_mappers_from_wide_dataframe(

--- a/test_mecfs_bio/unit/build_system/task/magma/test_magma_forward_stepwise_select_task.py
+++ b/test_mecfs_bio/unit/build_system/task/magma/test_magma_forward_stepwise_select_task.py
@@ -12,6 +12,7 @@ from mecfs_bio.build_system.meta.simple_directory_meta import SimpleDirectoryMet
 from mecfs_bio.build_system.meta.simple_file_meta import SimpleFileMeta
 from mecfs_bio.build_system.task.fake_task import FakeTask
 from mecfs_bio.build_system.task.magma.magma_forward_stepwise_select_task import (
+    RETAINED_CLUSTERS_COLUMN,
     MagmaForwardStepwiseSelectTask,
     generate_mappers_from_wide_dataframe,
     generate_wide_dataframe,
@@ -84,3 +85,58 @@ def test_forward_stepwise_when_missing_data(tmp_path: Path):
     assert isinstance(result, FileAsset)
     result_df = pd.read_csv(result.path)
     assert len(result_df) == 0
+
+    assert len(result_df) == 0
+
+
+def test_forward_stepwise_single_significant_cluster(tmp_path: Path):
+    """
+    When only one cluster is significant the pairwise conditional analysis has no
+    pairs and produces an empty output.  The lone significant cluster should still
+    be retained rather than discarded.
+    """
+    marg_df = pd.DataFrame(
+        {
+            MAGMA_VARIABLE_COLUMN: ["Cluster1", "Cluster2", "Cluster3"],
+            MAGMA_P_COLUMN: [1e-6, 0.5, 0.8],
+        }
+    )
+    # Mirror the real pipeline: with a single significant cluster there are no
+    # pairs to condition on, so the conditional output is header-only.
+    empty_cond_df = pd.DataFrame(
+        {MAGMA_VARIABLE_COLUMN: [], MAGMA_MODEL_COLUMN: [], MAGMA_P_COLUMN: []}
+    )
+    marg_dir_path = tmp_path / "marg_df.parquet"
+    cond_dir_path = tmp_path / "cond_df.parquet"
+    marg_dir_path.mkdir()
+    cond_dir_path.mkdir()
+    marg_df.to_csv(
+        marg_dir_path / (GENE_SET_ANALYSIS_OUTPUT_STEM_NAME + ".gsa.out"),
+        sep="\t",
+        index=False,
+    )
+    empty_cond_df.to_csv(
+        cond_dir_path / (GENE_SET_ANALYSIS_OUTPUT_STEM_NAME + ".gsa.out"),
+        sep="\t",
+        index=False,
+    )
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    tsk = MagmaForwardStepwiseSelectTask(
+        meta=SimpleFileMeta("stepwise"),
+        magma_marginal_output_task=FakeTask(SimpleDirectoryMeta("marginal")),
+        magma_conditional_output_task=FakeTask(SimpleDirectoryMeta("conditional")),
+        significance_threshold=0.01,
+    )
+
+    def fetch(asset_id: AssetId) -> Asset:
+        if asset_id == "marginal":
+            return DirectoryAsset(marg_dir_path)
+        if asset_id == "conditional":
+            return DirectoryAsset(cond_dir_path)
+        raise ValueError("Unknown asset id")
+
+    result = tsk.execute(fetch=fetch, scratch_dir=scratch, wf=SimpleWF())
+    assert isinstance(result, FileAsset)
+    result_df = pd.read_csv(result.path)
+    assert result_df[RETAINED_CLUSTERS_COLUMN].tolist() == ["Cluster1"]


### PR DESCRIPTION
- I noticed that in the forward stepwise analysis of MAGMA results, if there is only one significant cluster, forward stepwise analysis returns an empty list for the list of significant clusters.
- Instead, it should return a singleton list: a single significant cluster is obviously independently significant, as there are no other significant clusters for it to depend on.
- This PR fixes this bug.