### PR TITLE
run correlation on migraine, fix issues 

### DIFF
--- a/mecfs_bio/analysis/ct_ldsc_analysis.py
+++ b/mecfs_bio/analysis/ct_ldsc_analysis.py
@@ -7,13 +7,24 @@ Bulik-Sullivan, Brendan, et al. "An atlas of genetic correlations across human d
 """
 
 from mecfs_bio.analysis.runner.default_runner import DEFAULT_RUNNER
+from mecfs_bio.assets.gwas.multi_trait.genetic_correlation.ct_ldsc.ct_ldsc_initial_asset_generator import (
+    CT_LDSC_INITIAL_ASSET_GENERATOR,
+)
 from mecfs_bio.assets.gwas.multi_trait.genetic_correlation.ct_ldsc.ct_ldsc_plot import (
     CT_LDSC_INITIAL_PLOT,
+)
+from mecfs_bio.build_system.scheduler.topological_scheduler import (
+    TopologicalSchedulerSettings,
 )
 
 
 def initial_ct_ldsc_analysis():
-    DEFAULT_RUNNER.run([CT_LDSC_INITIAL_PLOT], incremental_save=True)
+    DEFAULT_RUNNER.run(
+        [CT_LDSC_INITIAL_PLOT],
+        incremental_save=True,
+        must_rebuild_transitive=[CT_LDSC_INITIAL_ASSET_GENERATOR.aggregation_task],
+        settings=TopologicalSchedulerSettings(print_progress=True),
+    )
 
 
 if __name__ == "__main__":

--- a/mecfs_bio/analysis/ct_ldsc_analysis.py
+++ b/mecfs_bio/analysis/ct_ldsc_analysis.py
@@ -7,24 +7,13 @@ Bulik-Sullivan, Brendan, et al. "An atlas of genetic correlations across human d
 """
 
 from mecfs_bio.analysis.runner.default_runner import DEFAULT_RUNNER
-from mecfs_bio.assets.gwas.multi_trait.genetic_correlation.ct_ldsc.ct_ldsc_initial_asset_generator import (
-    CT_LDSC_INITIAL_ASSET_GENERATOR,
-)
 from mecfs_bio.assets.gwas.multi_trait.genetic_correlation.ct_ldsc.ct_ldsc_plot import (
     CT_LDSC_INITIAL_PLOT,
-)
-from mecfs_bio.build_system.scheduler.topological_scheduler import (
-    TopologicalSchedulerSettings,
 )
 
 
 def initial_ct_ldsc_analysis():
-    DEFAULT_RUNNER.run(
-        [CT_LDSC_INITIAL_PLOT],
-        incremental_save=True,
-        must_rebuild_transitive=[CT_LDSC_INITIAL_ASSET_GENERATOR.aggregation_task],
-        settings=TopologicalSchedulerSettings(print_progress=True),
-    )
+    DEFAULT_RUNNER.run([CT_LDSC_INITIAL_PLOT], incremental_save=True)
 
 
 if __name__ == "__main__":

--- a/mecfs_bio/asset_generator/annovar_37_basic_rsid_assignment.py
+++ b/mecfs_bio/asset_generator/annovar_37_basic_rsid_assignment.py
@@ -45,14 +45,22 @@ def annovar_37_basic_rsid_assignment(
     base_name: str,
     use_gwaslab_rsids_convention: bool = False,
     drop_palindromic_ambiguous: bool = True,
+    filter_indels_in_harmonized: bool = False,
 ) -> RSIDAssignmentTaskGroup:
     """
     Asset generator that creates a chain of tasks to assign rsids to existing build 37 sumstats datasets using the annovar dbSNP reference data
+
+    Set filter_indels_in_harmonized to drop indels before harmonization.  This is
+    useful for datasets containing very long indel/structural-variant alleles: gwaslab
+    harmonization materializes the allele columns as fixed-width numpy unicode arrays,
+    so a single very long allele can blow up memory across every row.  Indels are not
+    used by the downstream SNP-based analyses (LDSC genetic correlation, MAGMA).
     """
     harmonized_task = GWASLabTransformSumstatsTask.create_from_source_task(
         sumstats_task,
         asset_id=base_name + "__harmonized",
         spec=GwasLabTransformSpec(
+            filter_indels=filter_indels_in_harmonized,
             harmonize_options=HarmonizationOptions(
                 ref_infer=GWASLabVCFRef(name="1kg_eur_hg19", ref_alt_freq="AF"),
                 ref_seq="ucsc_genome_hg19",
@@ -60,7 +68,7 @@ def annovar_37_basic_rsid_assignment(
                 drop_missing_from_ref_seq=True,
                 drop_missing_from_ref_infer_or_ambiguous=drop_palindromic_ambiguous,
                 cores=4,
-            )
+            ),
         ),
     )
     dump_parquet_task = GwasLabSumstatsToTableTask.create_from_source_task(

--- a/mecfs_bio/asset_generator/concrete_standard_analysis_task_generator.py
+++ b/mecfs_bio/asset_generator/concrete_standard_analysis_task_generator.py
@@ -357,6 +357,7 @@ def concrete_standard_analysis_generator_no_rsid(
     pre_sldsc_pipe: DataProcessingPipe = IdentityPipe(),
     include_master_gene_lists: bool = True,
     drop_palindromic_in_harmonized: bool = False,
+    filter_indels_in_harmonized: bool = False,
     include_hba_magma_tasks: bool = True,
     include_independent_cluster_plot_in_hba: bool = True,
     hbp_plot_settings: PlotSettings = PlotSettings("plotly_white"),
@@ -382,6 +383,7 @@ def concrete_standard_analysis_generator_no_rsid(
         base_name=base_name,
         use_gwaslab_rsids_convention=True,
         drop_palindromic_ambiguous=drop_palindromic_in_harmonized,
+        filter_indels_in_harmonized=filter_indels_in_harmonized,
     )
     standard_tasks = concrete_standard_analysis_generator_assume_already_has_rsid(
         base_name=base_name,

--- a/mecfs_bio/assets/gwas/ebv_dna/nyeo_et_al/analysis/ebv_dna_standard_analysis.py
+++ b/mecfs_bio/assets/gwas/ebv_dna/nyeo_et_al/analysis/ebv_dna_standard_analysis.py
@@ -29,6 +29,11 @@ EBV_DNA_STANDARD_ANALYSIS = concrete_standard_analysis_generator_no_rsid(
     sample_size=490_560,
     pre_pipe_after_rsid_assignment=CompositePipe([ComputePPipe()]),
     drop_palindromic_in_harmonized=False,
+    # The Nyeo EBV DNA sumstats contain very long indel/structural-variant alleles
+    # (up to 662 bp).  gwaslab harmonization materializes the allele columns as
+    # fixed-width numpy unicode arrays, so a single long allele blows up memory across
+    # all ~17M rows.  Indels are not used by the downstream SNP-based analyses.
+    filter_indels_in_harmonized=True,
     include_hba_magma_tasks=True,
     include_independent_cluster_plot_in_hba=True,
     hbp_plot_settings=PlotSettings("plotly_white"),

--- a/mecfs_bio/assets/gwas/multi_trait/genetic_correlation/ct_ldsc/ct_ldsc_initial_asset_generator.py
+++ b/mecfs_bio/assets/gwas/multi_trait/genetic_correlation/ct_ldsc/ct_ldsc_initial_asset_generator.py
@@ -36,6 +36,9 @@ from mecfs_bio.assets.gwas.me_cfs.decode_me.auxiliary.prevalance_info import (
 from mecfs_bio.assets.gwas.me_cfs.decode_me.processed_gwas_data.decode_me_with_annovar_37_rsids_sumstats import (
     DECODEME_ME_SUMSTATS_37_WITH_ANNOVAR_RSID,
 )
+from mecfs_bio.assets.gwas.migraine.uk_biobank_2025.analysis.uk_biobank_2025_migraine_standard_analysis import (
+    UK_BIOBANK_2025_EUR_MIGRAINE_STANDARD_ANALYSIS,
+)
 from mecfs_bio.assets.gwas.multisite_pain.johnston_et_al.analysis.johnston_standard_analysis import (
     JOHNSTON_ET_AL_PAIN_STANDARD_ANALYSIS,
 )
@@ -61,6 +64,7 @@ from mecfs_bio.assets.reference_data.linkage_disequilibrium_score_reference_data
     THOUSAND_GENOME_EUR_LD_REFERENCE_DATA_V1_EXTRACTED,
 )
 from mecfs_bio.build_system.task.gwaslab.gwaslab_genetic_corr_by_ct_ldsc_task import (
+    BinaryPhenotypeSampleInfo,
     QuantPhenotype,
     SumstatsSource,
 )
@@ -182,6 +186,15 @@ CT_LDSC_INITIAL_ASSET_GENERATOR = genetic_corr_by_ct_ldsc_asset_generator(
             sample_info=QuantPhenotype(),
             pipe=CompositePipe(
                 [SetColToConstantPipe(GWASLAB_SAMPLE_SIZE_COLUMN, 490_560)]
+            ),
+        ),
+        SumstatsSource(
+            UK_BIOBANK_2025_EUR_MIGRAINE_STANDARD_ANALYSIS.magma_tasks.sumstats_task,
+            alias="Migraine",
+            sample_info=BinaryPhenotypeSampleInfo(
+                sample_prevalence=25393 / 458440,  # from gwas catalog page
+                estimated_population_prevalence=0.104,  # UK prevalence from https://pmc.ncbi.nlm.nih.gov/articles/PMC11753071/
+                total_sample_size=458440,  # 25393 cases + 433047 controls; the UK Biobank migraine sumstats carry no per-SNP N column
             ),
         ),
         # SumstatsSource(

--- a/mecfs_bio/build_system/task/gwaslab/gwaslab_create_sumstats_task.py
+++ b/mecfs_bio/build_system/task/gwaslab/gwaslab_create_sumstats_task.py
@@ -25,6 +25,7 @@ from typing import Literal, Sequence
 import gwaslab
 import gwaslab as gl
 import narwhals
+import pandas as pd
 from attrs import frozen
 from gwaslab.util.util_in_filter_value import _exclude_sexchr
 
@@ -340,6 +341,27 @@ class GwasLabTransformSpec:
     liftover_to: GenomeBuild | None = None
 
 
+def _prune_unused_allele_categories(sumstats: gl.Sumstats) -> None:
+    """
+    Drop unused categories from the EA and NEA columns in place.
+
+    gwaslab stores alleles as pandas category dtype.  Filtering out rows (e.g. indels)
+    removes the rows but leaves the now-unused categories in place, including any very
+    long indel or structural-variant alleles.  Harmonization later calls astype(str) on
+    these columns, which materializes a fixed-width numpy unicode array sized to the
+    longest category across every remaining row, blowing up memory even when no long
+    allele is actually present.  Pruning unused categories keeps that array narrow.
+
+    remove_unused_categories operates on the (small) category index and integer codes,
+    so it never materializes the large per-row string array that astype(str) would.
+    """
+    for col in ("EA", "NEA"):
+        if col in sumstats.data.columns and isinstance(
+            sumstats.data[col].dtype, pd.CategoricalDtype
+        ):
+            sumstats.data[col] = sumstats.data[col].cat.remove_unused_categories()
+
+
 def transform_gwaslab_sumstats(
     sumstats: gl.Sumstats,
     spec: GwasLabTransformSpec,
@@ -373,6 +395,7 @@ def transform_gwaslab_sumstats(
     if spec.exclude_sexchr:
         sumstats = _exclude_sexchr(sumstats)
     if spec.harmonize_options is not None:
+        _prune_unused_allele_categories(sumstats)
         _do_harmonization(
             sumstats,
             basic_check=(not spec.basic_check),


### PR DESCRIPTION
- Add UK Biobank Migraine GWAS to genetic correlation study.
- When rerunning the genetic correlation analysis, I encountered an issue with the EBV DNA GWAS.  The problem seemed to be that this GWAS has some very large structural variants.  GWASLAB manipulates the EA/NEA columns in a way that blows up memory consumption for such variants.
- To work around this, I added the option to exclude indels in standard analysis
- If I have the time/energy, I may open an uptream issue in GWASLAB
- Closes #864 
- I'll update correlation docs in a future PR
 Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
