### PR TITLE
Extra eaf checks

### DIFF
--- a/mecfs_bio/build_system/task/filter_snps_by_frequency.py
+++ b/mecfs_bio/build_system/task/filter_snps_by_frequency.py
@@ -52,17 +52,12 @@ class FilterSNPsFrequencyTask(Task):
         )
 
         # Fail fast if the frequency column is not on the [0, 1] fraction scale that
-        # this task (and every downstream consumer) assumes. The most common upstream
-        # mistake is a column reported as a percentage (0-100), which silently passes
-        # the MAF filter but corrupts every downstream analysis. Check the raw column
-        # bounds directly so the error message can point at the likely cause.
+        # this task (and every downstream consumer) assumes.
         raw_min = float(df.select(nw.col(self.allele_freq_col).min()).collect().item())
         raw_max = float(df.select(nw.col(self.allele_freq_col).max()).collect().item())
         assert 0 <= raw_min <= 1 and 0 <= raw_max <= 1, (
             f"Allele frequency column {self.allele_freq_col!r} has values outside the "
-            f"[0, 1] fraction range (observed min={raw_min}, max={raw_max}). Allele "
-            "frequencies must be fractions, not percentages. If the source reports a "
-            "percentage (0-100), scale it by 1/100 before this task."
+            f"[0, 1] fraction range (observed min={raw_min}, max={raw_max})."
         )
 
         freq = nw.min_horizontal(

--- a/mecfs_bio/build_system/task/filter_snps_by_frequency.py
+++ b/mecfs_bio/build_system/task/filter_snps_by_frequency.py
@@ -51,8 +51,6 @@ class FilterSNPsFrequencyTask(Task):
             meta=self.raw_gwas_task.meta,
         )
 
-        # Fail fast if the frequency column is not on the [0, 1] fraction scale that
-        # this task (and every downstream consumer) assumes.
         raw_min = float(df.select(nw.col(self.allele_freq_col).min()).collect().item())
         raw_max = float(df.select(nw.col(self.allele_freq_col).max()).collect().item())
         assert 0 <= raw_min <= 1 and 0 <= raw_max <= 1, (

--- a/mecfs_bio/build_system/task/filter_snps_by_frequency.py
+++ b/mecfs_bio/build_system/task/filter_snps_by_frequency.py
@@ -50,12 +50,26 @@ class FilterSNPsFrequencyTask(Task):
             asset=fetch(self.raw_gwas_task.asset_id),
             meta=self.raw_gwas_task.meta,
         )
-        result = df.filter(
-            nw.min_horizontal(
-                nw.col(self.allele_freq_col), 1 - nw.col(self.allele_freq_col)
-            )
-            >= self.freq_thresh
+
+        # Fail fast if the frequency column is not on the [0, 1] fraction scale that
+        # this task (and every downstream consumer) assumes. The most common upstream
+        # mistake is a column reported as a percentage (0-100), which silently passes
+        # the MAF filter but corrupts every downstream analysis. Check the raw column
+        # bounds directly so the error message can point at the likely cause.
+        raw_min = float(df.select(nw.col(self.allele_freq_col).min()).collect().item())
+        raw_max = float(df.select(nw.col(self.allele_freq_col).max()).collect().item())
+        assert 0 <= raw_min <= 1 and 0 <= raw_max <= 1, (
+            f"Allele frequency column {self.allele_freq_col!r} has values outside the "
+            f"[0, 1] fraction range (observed min={raw_min}, max={raw_max}). Allele "
+            "frequencies must be fractions, not percentages. If the source reports a "
+            "percentage (0-100), scale it by 1/100 before this task."
         )
+
+        freq = nw.min_horizontal(
+            nw.col(self.allele_freq_col), 1 - nw.col(self.allele_freq_col)
+        )
+
+        result = df.filter(freq >= self.freq_thresh)
         target_path = scratch_dir / "tmp.parqet"
         result.sink_parquet(target_path)
         return FileAsset(target_path)
@@ -69,7 +83,7 @@ class FilterSNPsFrequencyTask(Task):
         freq_thresh: float = 0.05,
     ) -> Task:
         source_meta = raw_gwas_task.meta
-        assert isinstance(source_meta, GWASSummaryDataFileMeta)
+        assert isinstance(source_meta, (GWASSummaryDataFileMeta, FilteredGWASDataMeta))
         meta = FilteredGWASDataMeta(
             id=AssetId(id),
             trait=source_meta.trait,

--- a/mecfs_bio/build_system/task/gwaslab/gwaslab_create_sumstats_task.py
+++ b/mecfs_bio/build_system/task/gwaslab/gwaslab_create_sumstats_task.py
@@ -199,15 +199,6 @@ ValidGwaslabFormat = GwaslabKnownFormat | GWASLabColumnSpecifiers
 def _validate_eaf_in_range(sumstats: gl.Sumstats) -> None:
     """
     Fail fast if the effect-allele-frequency column is not on the [0, 1] fraction scale.
-
-    gwaslab (and everything downstream) assumes allele frequencies are fractions. A
-    column reported as a percentage (0-100) passes through gwaslab silently but corrupts
-    every MAF-dependent step. This runs after sumstats construction, so gwaslab has
-    already renamed whichever source column held the frequency (be it explicit column
-    specifiers or a named format such as regenie) to its standard EAF column. Checking
-    that standardized column makes the guard format-agnostic. Variants with no reported
-    frequency are stored as NaN; those are ignored here (nanmin/nanmax) since they are a
-    separate concern from a wrong scale.
     """
     if GWASLAB_EFFECT_ALLELE_FREQ_COL not in sumstats.data.columns:
         return
@@ -215,13 +206,11 @@ def _validate_eaf_in_range(sumstats: gl.Sumstats) -> None:
     eaf_min = float(eaf.min(skipna=True))
     eaf_max = float(eaf.max(skipna=True))
     if pd.isna(eaf_min) or pd.isna(eaf_max):
-        # Column is present but entirely NaN; nothing to validate.
+        logger.debug("EAF column present, but entirely NAN")
         return
     assert 0 <= eaf_min <= 1 and 0 <= eaf_max <= 1, (
         f"Effect allele frequency column {GWASLAB_EFFECT_ALLELE_FREQ_COL!r} has values "
         f"outside the [0, 1] fraction range (observed min={eaf_min}, max={eaf_max}). "
-        "Allele frequencies must be fractions, not percentages. If the source reports a "
-        "percentage (0-100), scale it by 1/100 before creating the sumstats."
     )
 
 

--- a/mecfs_bio/build_system/task/gwaslab/gwaslab_create_sumstats_task.py
+++ b/mecfs_bio/build_system/task/gwaslab/gwaslab_create_sumstats_task.py
@@ -41,6 +41,7 @@ from mecfs_bio.build_system.rebuilder.fetch.base_fetch import Fetch
 from mecfs_bio.build_system.task.base_task import Task
 from mecfs_bio.build_system.wf.base_wf import WF
 from mecfs_bio.constants.gwaslab_constants import (
+    GWASLAB_EFFECT_ALLELE_FREQ_COL,
     GWASLAB_STATUS_COL,
     GwaslabKnownFormat,
 )
@@ -195,6 +196,35 @@ class GWASLabColumnSpecifiers:
 ValidGwaslabFormat = GwaslabKnownFormat | GWASLabColumnSpecifiers
 
 
+def _validate_eaf_in_range(sumstats: gl.Sumstats) -> None:
+    """
+    Fail fast if the effect-allele-frequency column is not on the [0, 1] fraction scale.
+
+    gwaslab (and everything downstream) assumes allele frequencies are fractions. A
+    column reported as a percentage (0-100) passes through gwaslab silently but corrupts
+    every MAF-dependent step. This runs after sumstats construction, so gwaslab has
+    already renamed whichever source column held the frequency (be it explicit column
+    specifiers or a named format such as regenie) to its standard EAF column. Checking
+    that standardized column makes the guard format-agnostic. Variants with no reported
+    frequency are stored as NaN; those are ignored here (nanmin/nanmax) since they are a
+    separate concern from a wrong scale.
+    """
+    if GWASLAB_EFFECT_ALLELE_FREQ_COL not in sumstats.data.columns:
+        return
+    eaf = sumstats.data[GWASLAB_EFFECT_ALLELE_FREQ_COL]
+    eaf_min = float(eaf.min(skipna=True))
+    eaf_max = float(eaf.max(skipna=True))
+    if pd.isna(eaf_min) or pd.isna(eaf_max):
+        # Column is present but entirely NaN; nothing to validate.
+        return
+    assert 0 <= eaf_min <= 1 and 0 <= eaf_max <= 1, (
+        f"Effect allele frequency column {GWASLAB_EFFECT_ALLELE_FREQ_COL!r} has values "
+        f"outside the [0, 1] fraction range (observed min={eaf_min}, max={eaf_max}). "
+        "Allele frequencies must be fractions, not percentages. If the source reports a "
+        "percentage (0-100), scale it by 1/100 before creating the sumstats."
+    )
+
+
 def _get_sumstats(
     x: narwhals.LazyFrame,
     fmt: ValidGwaslabFormat,
@@ -303,6 +333,7 @@ class GWASLabCreateSumstatsTask(Task):
         df = self.pre_pipe.process(df)
         logger.debug("Fetching source dataframe asset...")
         sumstats = _get_sumstats(df, self.fmt, drop_cols=self.drop_col_list)
+        _validate_eaf_in_range(sumstats)
         transform_spec = GwasLabTransformSpec(
             basic_check=self.basic_check,
             genome_build=self.genome_build,

--- a/mecfs_bio/build_system/task/gwaslab/gwaslab_create_sumstats_task.py
+++ b/mecfs_bio/build_system/task/gwaslab/gwaslab_create_sumstats_task.py
@@ -197,9 +197,6 @@ ValidGwaslabFormat = GwaslabKnownFormat | GWASLabColumnSpecifiers
 
 
 def _validate_eaf_in_range(sumstats: gl.Sumstats) -> None:
-    """
-    Fail fast if the effect-allele-frequency column is not on the [0, 1] fraction scale.
-    """
     if GWASLAB_EFFECT_ALLELE_FREQ_COL not in sumstats.data.columns:
         return
     eaf = sumstats.data[GWASLAB_EFFECT_ALLELE_FREQ_COL]

--- a/mecfs_bio/build_system/task/whitespace_sep_text_to_parquet_task.py
+++ b/mecfs_bio/build_system/task/whitespace_sep_text_to_parquet_task.py
@@ -98,7 +98,11 @@ class WhitespaceSepTextToParquetTask(Task):
         rows = 0
         # sep=r"\s+" matches read_dataframe.scan_dataframe; pandas infers gzip from the
         # path extension. The first chunk fixes the schema; later chunks are cast to it
-        # (safe=False) so an all-null column that pandas widens later cannot drift.
+        # with safe=True. Because pandas infers dtypes per chunk, a column whose values
+        # widen later (X/Y in a numeric chromosome column, or a decimal in a column the
+        # first chunk saw as integer) would not fit the first chunk's schema; safe=True
+        # makes that a loud failure instead of silently truncating. Widenings and
+        # NaN-as-missing are still handled without error.
         reader = pd.read_csv(
             source_asset.path,
             sep=r"\s+",
@@ -114,9 +118,20 @@ class WhitespaceSepTextToParquetTask(Task):
                     out_path, schema, compression=self.compression
                 )
             else:
-                table = pa.Table.from_pandas(
-                    chunk, schema=schema, preserve_index=False, safe=False
-                )
+                try:
+                    table = pa.Table.from_pandas(
+                        chunk, schema=schema, preserve_index=False, safe=True
+                    )
+                except pa.ArrowInvalid as exc:
+                    raise ValueError(
+                        f"Chunk starting at row {rows} does not fit the schema "
+                        f"inferred from the first chunk ({schema}). pandas infers "
+                        "dtypes per chunk, so a column whose values widen later "
+                        "(e.g. X/Y in a numeric chromosome column, or a decimal in "
+                        "a column the first chunk saw as integer) will not fit. Pass "
+                        "dtype={...} to pin the affected column's type. Underlying "
+                        f"error: {exc}"
+                    ) from exc
             assert writer is not None
             writer.write_table(table)
             rows += chunk.shape[0]

--- a/mecfs_bio/build_system/task/whitespace_sep_text_to_parquet_task.py
+++ b/mecfs_bio/build_system/task/whitespace_sep_text_to_parquet_task.py
@@ -1,0 +1,155 @@
+"""
+Task that converts an arbitrary-whitespace-separated (optionally gzipped) text
+table into parquet, streaming in bounded-memory chunks.
+
+Polars cannot read arbitrary-whitespace-separated files, so the read_spec machinery
+falls back to a single eager pandas read for DataFrameWhiteSpaceSepTextFormat (see
+mecfs_bio/build_system/meta/read_spec/read_dataframe.py). For a large meta-analysis
+such as the deCODE summary statistics (tens of millions of rows, object-dtype string
+columns), that materialises the whole table in pandas and then copies it into polars,
+which exhausts memory.
+
+Converting the file to parquet once, up front, lets every downstream task scan it
+lazily with projection pushdown. The conversion itself reads the source in row
+chunks and appends each chunk to the parquet file, so peak memory is bounded by
+chunk_size rather than the size of the whole table. The chunked read uses the same
+pandas whitespace parsing (sep=r"\\s+") as the read_spec machinery, so the parsed
+result is identical to reading the file directly.
+"""
+
+from pathlib import Path, PurePath
+from typing import Mapping
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import structlog
+from attrs import frozen
+
+from mecfs_bio.build_system.asset.base_asset import Asset
+from mecfs_bio.build_system.asset.file_asset import FileAsset
+from mecfs_bio.build_system.meta.asset_id import AssetId
+from mecfs_bio.build_system.meta.base_meta import FileMeta
+from mecfs_bio.build_system.meta.filtered_gwas_data_meta import FilteredGWASDataMeta
+from mecfs_bio.build_system.meta.gwas_summary_file_meta import GWASSummaryDataFileMeta
+from mecfs_bio.build_system.meta.meta import Meta
+from mecfs_bio.build_system.meta.read_spec.dataframe_read_spec import (
+    DataFrameParquetFormat,
+    DataFrameReadSpec,
+    DataFrameWhiteSpaceSepTextFormat,
+)
+from mecfs_bio.build_system.rebuilder.fetch.base_fetch import Fetch
+from mecfs_bio.build_system.task.base_task import Task
+from mecfs_bio.build_system.wf.base_wf import WF
+
+logger = structlog.get_logger()
+
+
+@frozen
+class WhitespaceSepTextToParquetTask(Task):
+    meta: Meta
+    source_task: Task
+    chunk_size: int = 2_000_000
+    compression: str = "zstd"
+    dtype: Mapping[str, str] | None = None
+
+    def __attrs_post_init__(self) -> None:
+        # Shift-left: reject a source that is not arbitrary-whitespace-separated text
+        # at construction time rather than waiting until execute.
+        self._whitespace_format()
+
+    @property
+    def deps(self) -> list["Task"]:
+        return [self.source_task]
+
+    @property
+    def _source_id(self) -> AssetId:
+        return self.source_task.asset_id
+
+    @property
+    def _source_meta(self) -> FileMeta:
+        meta = self.source_task.meta
+        assert isinstance(meta, FileMeta)
+        return meta
+
+    def _whitespace_format(self) -> DataFrameWhiteSpaceSepTextFormat:
+        read_spec = self._source_meta.read_spec
+        assert read_spec is not None, "source asset has no read_spec"
+        fmt = read_spec.format
+        assert isinstance(fmt, DataFrameWhiteSpaceSepTextFormat), (
+            "source asset must be arbitrary-whitespace-separated text"
+        )
+        return fmt
+
+    def execute(self, scratch_dir: Path, fetch: Fetch, wf: WF) -> Asset:
+        source_asset = fetch(self._source_id)
+        assert isinstance(source_asset, FileAsset)
+        fmt = self._whitespace_format()
+
+        extra_options: dict = {}
+        if fmt.col_names is not None:
+            extra_options["names"] = fmt.col_names
+        if self.dtype is not None:
+            extra_options["dtype"] = self.dtype
+
+        out_path = scratch_dir / "output_file.parquet"
+        writer: pq.ParquetWriter | None = None
+        schema: pa.Schema | None = None
+        rows = 0
+        # sep=r"\s+" matches read_dataframe.scan_dataframe; pandas infers gzip from the
+        # path extension. The first chunk fixes the schema; later chunks are cast to it
+        # (safe=False) so an all-null column that pandas widens later cannot drift.
+        reader = pd.read_csv(
+            source_asset.path,
+            sep=r"\s+",
+            comment=fmt.comment_code,
+            chunksize=self.chunk_size,
+            **extra_options,
+        )
+        for chunk in reader:
+            if schema is None:
+                table = pa.Table.from_pandas(chunk, preserve_index=False)
+                schema = table.schema
+                writer = pq.ParquetWriter(
+                    out_path, schema, compression=self.compression
+                )
+            else:
+                table = pa.Table.from_pandas(
+                    chunk, schema=schema, preserve_index=False, safe=False
+                )
+            assert writer is not None
+            writer.write_table(table)
+            rows += chunk.shape[0]
+        assert writer is not None, "source table is empty"
+        writer.close()
+        logger.info(f"Converted {rows} rows to parquet at {out_path}")
+        return FileAsset(out_path)
+
+    @classmethod
+    def create(
+        cls,
+        source_task: Task,
+        asset_id: str,
+        sub_dir: str | PurePath = PurePath("processed"),
+        chunk_size: int = 2_000_000,
+        compression: str = "zstd",
+        dtype: Mapping[str, str] | None = None,
+    ) -> "WhitespaceSepTextToParquetTask":
+        source_meta = source_task.meta
+        assert isinstance(
+            source_meta, (GWASSummaryDataFileMeta, FilteredGWASDataMeta)
+        ), "source task must carry GWAS summary metadata"
+        meta = FilteredGWASDataMeta(
+            id=AssetId(asset_id),
+            trait=source_meta.trait,
+            project=source_meta.project,
+            sub_dir=sub_dir,
+            read_spec=DataFrameReadSpec(format=DataFrameParquetFormat()),
+        )
+        return cls(
+            meta=meta,
+            source_task=source_task,
+            chunk_size=chunk_size,
+            compression=compression,
+            dtype=dtype,
+        )

--- a/test_mecfs_bio/unit/build_system/task/gwaslab/test_gwaslab_create_sumstats_task.py
+++ b/test_mecfs_bio/unit/build_system/task/gwaslab/test_gwaslab_create_sumstats_task.py
@@ -2,7 +2,9 @@ import pickle
 from pathlib import Path
 
 import gwaslab
+import gwaslab as gl
 import pandas as pd
+import pytest
 
 from mecfs_bio.build_system.asset.base_asset import Asset
 from mecfs_bio.build_system.asset.file_asset import FileAsset
@@ -16,6 +18,7 @@ from mecfs_bio.build_system.meta.read_spec.read_dataframe import scan_dataframe_
 from mecfs_bio.build_system.task.fake_task import FakeTask
 from mecfs_bio.build_system.task.gwaslab.gwaslab_create_sumstats_task import (
     GWASLabCreateSumstatsTask,
+    _validate_eaf_in_range,
 )
 from mecfs_bio.build_system.task.gwaslab.gwaslab_sumstats_to_table_task import (
     GwasLabSumstatsToTableTask,
@@ -71,3 +74,56 @@ def test_gwaslab_sumstats(
     )
     asset_2 = task_2.execute(scratch_dir=scratch_loc_2, wf=SimpleWF(), fetch=fetch_2)
     scan_dataframe_asset(asset=asset_2, meta=task_2.meta)
+
+
+def _regenie_sumstats_with_a1freq(a1freq: list[float]) -> gl.Sumstats:
+    n = len(a1freq)
+    df = pd.DataFrame(
+        {
+            "CHROM": [1] * n,
+            "GENPOS": list(range(100, 100 + n)),
+            "ID": [f"rs{i}" for i in range(n)],
+            "ALLELE0": ["A"] * n,
+            "ALLELE1": ["T"] * n,
+            "A1FREQ": a1freq,
+            "BETA": [0.1] * n,
+            "SE": [0.01] * n,
+            "LOG10P": [2.0] * n,
+            "N": [1000] * n,
+        }
+    )
+    return gl.Sumstats(df, fmt="regenie", verbose=False)
+
+
+def test_validate_eaf_in_range_rejects_percentage():
+    """
+    EAF supplied as a percentage (0-100) must fail fast, even via a named format where
+    gwaslab renames the source column (A1FREQ) to its standard EAF column.
+    """
+    sumstats = _regenie_sumstats_with_a1freq([0.1, 25.0, 50.0])
+    with pytest.raises(AssertionError, match="percentages"):
+        _validate_eaf_in_range(sumstats)
+
+
+def test_validate_eaf_in_range_accepts_fraction():
+    sumstats = _regenie_sumstats_with_a1freq([0.001, 0.25, 0.5, 0.999])
+    _validate_eaf_in_range(sumstats)
+
+
+def test_validate_eaf_in_range_no_eaf_column_is_noop():
+    """A sumstats with no EAF column must not raise."""
+    df = pd.DataFrame(
+        {
+            "CHROM": [1, 1],
+            "GENPOS": [100, 200],
+            "ID": ["rs1", "rs2"],
+            "ALLELE0": ["A", "C"],
+            "ALLELE1": ["T", "G"],
+            "BETA": [0.1, 0.1],
+            "SE": [0.01, 0.01],
+            "LOG10P": [2.0, 3.0],
+            "N": [1000, 1000],
+        }
+    )
+    sumstats = gl.Sumstats(df, fmt="regenie", verbose=False)
+    _validate_eaf_in_range(sumstats)

--- a/test_mecfs_bio/unit/build_system/task/gwaslab/test_gwaslab_create_sumstats_task.py
+++ b/test_mecfs_bio/unit/build_system/task/gwaslab/test_gwaslab_create_sumstats_task.py
@@ -101,7 +101,7 @@ def test_validate_eaf_in_range_rejects_percentage():
     gwaslab renames the source column (A1FREQ) to its standard EAF column.
     """
     sumstats = _regenie_sumstats_with_a1freq([0.1, 25.0, 50.0])
-    with pytest.raises(AssertionError, match="percentages"):
+    with pytest.raises(AssertionError):
         _validate_eaf_in_range(sumstats)
 
 

--- a/test_mecfs_bio/unit/build_system/task/test_filter_snps_by_frequency_task.py
+++ b/test_mecfs_bio/unit/build_system/task/test_filter_snps_by_frequency_task.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pandas as pd
+import pytest
 
 from mecfs_bio.build_system.asset.base_asset import Asset
 from mecfs_bio.build_system.asset.file_asset import FileAsset
@@ -68,3 +69,37 @@ def test_filter_snps_by_frequency_task(tmp_path: Path):
             "rs13_common",
         ]
     )
+
+
+def test_filter_snps_by_frequency_rejects_percentage_frequencies(tmp_path: Path):
+    """A frequency column reported as a percentage (0-100) must fail fast."""
+    df_loc = tmp_path / "df.csv"
+    pd.DataFrame(
+        {
+            "variant_id": ["rs1", "rs2", "rs3"],
+            # Percentage-encoded frequencies (max 50.0) rather than fractions.
+            "effect_allele_frequency": [0.1, 25.0, 50.0],
+        }
+    ).to_csv(df_loc, index=False)
+    scratch_loc = tmp_path / "scratch"
+    scratch_loc.mkdir(exist_ok=True, parents=True)
+    task = FilterSNPsFrequencyTask(
+        meta=SimpleFileMeta(
+            AssetId("fake"),
+            read_spec=DataFrameReadSpec(format=DataFrameTextFormat(separator=",")),
+        ),
+        raw_gwas_task=FakeTask(
+            SimpleFileMeta(
+                AssetId("dummy"),
+                read_spec=DataFrameReadSpec(format=DataFrameTextFormat(separator=",")),
+            ),
+        ),
+        allele_freq_col="effect_allele_frequency",
+        freq_thresh=0.01,
+    )
+
+    def fetch(asset_id: AssetId) -> Asset:
+        return FileAsset(df_loc)
+
+    with pytest.raises(AssertionError, match="percentages"):
+        task.execute(scratch_dir=scratch_loc, fetch=fetch, wf=SimpleWF())

--- a/test_mecfs_bio/unit/build_system/task/test_filter_snps_by_frequency_task.py
+++ b/test_mecfs_bio/unit/build_system/task/test_filter_snps_by_frequency_task.py
@@ -101,5 +101,5 @@ def test_filter_snps_by_frequency_rejects_percentage_frequencies(tmp_path: Path)
     def fetch(asset_id: AssetId) -> Asset:
         return FileAsset(df_loc)
 
-    with pytest.raises(AssertionError, match="percentages"):
+    with pytest.raises(AssertionError):
         task.execute(scratch_dir=scratch_loc, fetch=fetch, wf=SimpleWF())

--- a/test_mecfs_bio/unit/build_system/task/test_whitespace_sep_text_to_parquet_task.py
+++ b/test_mecfs_bio/unit/build_system/task/test_whitespace_sep_text_to_parquet_task.py
@@ -1,0 +1,118 @@
+import gzip
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from mecfs_bio.build_system.asset.base_asset import Asset
+from mecfs_bio.build_system.asset.file_asset import FileAsset
+from mecfs_bio.build_system.meta.asset_id import AssetId
+from mecfs_bio.build_system.meta.filtered_gwas_data_meta import FilteredGWASDataMeta
+from mecfs_bio.build_system.meta.gwas_summary_file_meta import GWASSummaryDataFileMeta
+from mecfs_bio.build_system.meta.read_spec.dataframe_read_spec import (
+    DataFrameParquetFormat,
+    DataFrameReadSpec,
+    DataFrameTextFormat,
+    DataFrameWhiteSpaceSepTextFormat,
+)
+from mecfs_bio.build_system.rebuilder.fetch.base_fetch import Fetch
+from mecfs_bio.build_system.task.fake_task import FakeTask
+from mecfs_bio.build_system.task.whitespace_sep_text_to_parquet_task import (
+    WhitespaceSepTextToParquetTask,
+)
+from mecfs_bio.build_system.wf.base_wf import SimpleWF
+
+# Variable-width spacing (like the deCODE alignment padding) plus a column that is "NA"
+# in early rows and numeric later, to exercise streaming parse and cross-chunk schema.
+_ROWS = [
+    "Chr PosB38 Cohorts EAFrq I2",
+    "chr1 100 -?????   0.10 NA",
+    "chr1 200 ?+???-   0.20 NA",
+    "chr2 300 -----?   0.30 NA",
+    "chr2 400 ??-???   0.40 42",
+    "chr3 500 ?----?   0.50 17",
+]
+
+
+def test_whitespace_sep_text_to_parquet_streams_and_preserves_values(tmp_path: Path):
+    src = tmp_path / "gwas.txt.gz"
+    with gzip.open(src, "wt") as f:
+        f.write("\n".join(_ROWS) + "\n")
+    scratch = tmp_path / "scratch"
+    scratch.mkdir(parents=True, exist_ok=True)
+
+    source_task = FakeTask(
+        meta=GWASSummaryDataFileMeta(
+            id=AssetId("raw"),
+            trait="rheumatoid_arthritis",
+            project="decode_ra_seropositive",
+            sub_dir="raw",
+            project_path=Path("gwas.txt.gz"),
+            read_spec=DataFrameReadSpec(
+                format=DataFrameWhiteSpaceSepTextFormat(comment_code="#")
+            ),
+        )
+    )
+    # chunk_size=2 forces three chunks, including the NA -> numeric transition.
+    task = WhitespaceSepTextToParquetTask.create(
+        source_task=source_task, asset_id="raw_parquet", chunk_size=2
+    )
+
+    class _Fetch(Fetch):
+        def __call__(self, asset_id: AssetId) -> Asset:
+            return FileAsset(src)
+
+    result = task.execute(scratch_dir=scratch, fetch=_Fetch(), wf=SimpleWF())
+    assert isinstance(result, FileAsset)
+
+    df = pl.read_parquet(result.path)
+    assert df.shape == (5, 5)
+    assert df["Cohorts"].to_list() == ["-?????", "?+???-", "-----?", "??-???", "?----?"]
+    assert df["PosB38"].to_list() == [100, 200, 300, 400, 500]
+    # Column is float across all chunks despite starting all-NA, and NAs become null.
+    assert df["I2"].dtype == pl.Float64
+    assert df["I2"].to_list()[:3] == [None, None, None]
+    assert df["I2"].to_list()[3:] == [42.0, 17.0]
+
+
+def test_create_derives_trait_project_and_parquet_read_spec():
+    source_task = FakeTask(
+        meta=GWASSummaryDataFileMeta(
+            id=AssetId("raw"),
+            trait="rheumatoid_arthritis",
+            project="decode_ra_seropositive",
+            sub_dir="raw",
+            project_path=Path("gwas.txt.gz"),
+            read_spec=DataFrameReadSpec(
+                format=DataFrameWhiteSpaceSepTextFormat(comment_code="#")
+            ),
+        )
+    )
+    task = WhitespaceSepTextToParquetTask.create(
+        source_task=source_task, asset_id="raw_parquet"
+    )
+    meta = task.meta
+    assert isinstance(meta, FilteredGWASDataMeta)
+    assert meta.trait == "rheumatoid_arthritis"
+    assert meta.project == "decode_ra_seropositive"
+    assert meta.read_spec is not None
+    assert isinstance(meta.read_spec.format, DataFrameParquetFormat)
+
+
+def test_rejects_non_whitespace_source_at_construction():
+    # Shift-left: a non-whitespace source must fail when the task is constructed,
+    # not later at execute time.
+    source_task = FakeTask(
+        meta=GWASSummaryDataFileMeta(
+            id=AssetId("raw"),
+            trait="rheumatoid_arthritis",
+            project="decode_ra_seropositive",
+            sub_dir="raw",
+            project_path=Path("gwas.tsv"),
+            read_spec=DataFrameReadSpec(format=DataFrameTextFormat(separator="\t")),
+        )
+    )
+    with pytest.raises(AssertionError):
+        WhitespaceSepTextToParquetTask.create(
+            source_task=source_task, asset_id="raw_parquet"
+        )

--- a/test_mecfs_bio/unit/build_system/task/test_whitespace_sep_text_to_parquet_task.py
+++ b/test_mecfs_bio/unit/build_system/task/test_whitespace_sep_text_to_parquet_task.py
@@ -7,12 +7,9 @@ import pytest
 from mecfs_bio.build_system.asset.base_asset import Asset
 from mecfs_bio.build_system.asset.file_asset import FileAsset
 from mecfs_bio.build_system.meta.asset_id import AssetId
-from mecfs_bio.build_system.meta.filtered_gwas_data_meta import FilteredGWASDataMeta
 from mecfs_bio.build_system.meta.gwas_summary_file_meta import GWASSummaryDataFileMeta
 from mecfs_bio.build_system.meta.read_spec.dataframe_read_spec import (
-    DataFrameParquetFormat,
     DataFrameReadSpec,
-    DataFrameTextFormat,
     DataFrameWhiteSpaceSepTextFormat,
 )
 from mecfs_bio.build_system.rebuilder.fetch.base_fetch import Fetch
@@ -141,46 +138,3 @@ def test_dtype_override_pins_mixed_chromosome_column(tmp_path: Path):
     assert isinstance(result, FileAsset)
     df = pl.read_parquet(result.path)
     assert df["Chr"].to_list() == ["1", "2", "X", "Y"]
-
-
-def test_create_derives_trait_project_and_parquet_read_spec():
-    source_task = FakeTask(
-        meta=GWASSummaryDataFileMeta(
-            id=AssetId("raw"),
-            trait="rheumatoid_arthritis",
-            project="decode_ra_seropositive",
-            sub_dir="raw",
-            project_path=Path("gwas.txt.gz"),
-            read_spec=DataFrameReadSpec(
-                format=DataFrameWhiteSpaceSepTextFormat(comment_code="#")
-            ),
-        )
-    )
-    task = WhitespaceSepTextToParquetTask.create(
-        source_task=source_task, asset_id="raw_parquet"
-    )
-    meta = task.meta
-    assert isinstance(meta, FilteredGWASDataMeta)
-    assert meta.trait == "rheumatoid_arthritis"
-    assert meta.project == "decode_ra_seropositive"
-    assert meta.read_spec is not None
-    assert isinstance(meta.read_spec.format, DataFrameParquetFormat)
-
-
-def test_rejects_non_whitespace_source_at_construction():
-    # Shift-left: a non-whitespace source must fail when the task is constructed,
-    # not later at execute time.
-    source_task = FakeTask(
-        meta=GWASSummaryDataFileMeta(
-            id=AssetId("raw"),
-            trait="rheumatoid_arthritis",
-            project="decode_ra_seropositive",
-            sub_dir="raw",
-            project_path=Path("gwas.tsv"),
-            read_spec=DataFrameReadSpec(format=DataFrameTextFormat(separator="\t")),
-        )
-    )
-    with pytest.raises(AssertionError):
-        WhitespaceSepTextToParquetTask.create(
-            source_task=source_task, asset_id="raw_parquet"
-        )

--- a/test_mecfs_bio/unit/build_system/task/test_whitespace_sep_text_to_parquet_task.py
+++ b/test_mecfs_bio/unit/build_system/task/test_whitespace_sep_text_to_parquet_task.py
@@ -75,6 +75,74 @@ def test_whitespace_sep_text_to_parquet_streams_and_preserves_values(tmp_path: P
     assert df["I2"].to_list()[3:] == [42.0, 17.0]
 
 
+# A chromosome column that is purely integer in the first chunk but uses X/Y later:
+# the classic case where per-chunk schema inference disagrees across chunks.
+_MIXED_CHR_ROWS = [
+    "Chr Pos",
+    "1 100",
+    "2 200",
+    "X 300",
+    "Y 400",
+]
+
+
+def _source_and_fetch(src: Path) -> tuple[FakeTask, Fetch]:
+    source_task = FakeTask(
+        meta=GWASSummaryDataFileMeta(
+            id=AssetId("raw"),
+            trait="rheumatoid_arthritis",
+            project="decode_ra_seropositive",
+            sub_dir="raw",
+            project_path=Path(src.name),
+            read_spec=DataFrameReadSpec(
+                format=DataFrameWhiteSpaceSepTextFormat(comment_code="#")
+            ),
+        )
+    )
+
+    class _Fetch(Fetch):
+        def __call__(self, asset_id: AssetId) -> Asset:
+            return FileAsset(src)
+
+    return source_task, _Fetch()
+
+
+def test_lossy_cross_chunk_type_change_raises(tmp_path: Path):
+    # Chr is int64 in the first chunk, then X/Y strings later. safe=True must turn
+    # this into a loud failure rather than silently corrupting the column.
+    src = tmp_path / "gwas.txt"
+    src.write_text("\n".join(_MIXED_CHR_ROWS) + "\n")
+    scratch = tmp_path / "scratch"
+    scratch.mkdir(parents=True, exist_ok=True)
+
+    source_task, fetch = _source_and_fetch(src)
+    task = WhitespaceSepTextToParquetTask.create(
+        source_task=source_task, asset_id="raw_parquet", chunk_size=2
+    )
+    with pytest.raises(ValueError, match="dtype="):
+        task.execute(scratch_dir=scratch, fetch=fetch, wf=SimpleWF())
+
+
+def test_dtype_override_pins_mixed_chromosome_column(tmp_path: Path):
+    # Pinning the offending column to str via dtype makes the same input succeed.
+    src = tmp_path / "gwas.txt"
+    src.write_text("\n".join(_MIXED_CHR_ROWS) + "\n")
+    scratch = tmp_path / "scratch"
+    scratch.mkdir(parents=True, exist_ok=True)
+
+    source_task, fetch = _source_and_fetch(src)
+    task = WhitespaceSepTextToParquetTask.create(
+        source_task=source_task,
+        asset_id="raw_parquet",
+        chunk_size=2,
+        dtype={"Chr": "str"},
+    )
+    result = task.execute(scratch_dir=scratch, fetch=fetch, wf=SimpleWF())
+    assert isinstance(result, FileAsset)
+    df = pl.read_parquet(result.path)
+    assert df["Chr"].to_list() == ["1", "2", "X", "Y"]
+
+
 def test_create_derives_trait_project_and_parquet_read_spec():
     source_task = FakeTask(
         meta=GWASSummaryDataFileMeta(


### PR DESCRIPTION
- While analzing an RA GWAS, I ran into an issue where I assumed the effect allele frequency column would be expressed as a fraction, but it was expressed as a percentage. 
- To prevent this problem in the future, I added checks to the createsumstats and filter by effect allele frequency tasks to detect out-of-range frequencies. This should allow us to fail fast in this case.
- I also added an unrelated utility task WhitespaceSepTextToParquetTask.  This converts a whitespace separated summary stats file to parquet, which is easier to work with.