### PR TITLE
Seropositive RA analysis+ LDSC guard against non-finite values 

### DIFF
--- a/experiments/tralfamadorian97/runs/ra_runs.py
+++ b/experiments/tralfamadorian97/runs/ra_runs.py
@@ -9,7 +9,7 @@ from mecfs_bio.assets.gwas.rheumtoid_arthritis.decode_seropositive.raw.download_
 
 def go():
     DEFAULT_RUNNER.run(
-        targets=SEROPOSITIVE_RA_STANDARD_ANALYSIS.tasks.magma_tasks.inner.terminal_tasks(),
+        targets=[SEROPOSITIVE_RA_STANDARD_ANALYSIS.tasks.heritability_markdown_task_unwrap],
         must_rebuild_transitive=[
             # SEROPOS_RA_FILTERED_FOR_FREQ,
         ],

--- a/mecfs_bio/assets/gwas/rheumtoid_arthritis/decode_seropositive/analysis/ra_seropositive_standard_analysis.py
+++ b/mecfs_bio/assets/gwas/rheumtoid_arthritis/decode_seropositive/analysis/ra_seropositive_standard_analysis.py
@@ -18,6 +18,9 @@ from mecfs_bio.build_system.sample_size_spec import PerVariantSampleSize
 from mecfs_bio.build_system.task.gwaslab.gwaslab_create_sumstats_task import (
     GWASLabColumnSpecifiers,
 )
+from mecfs_bio.build_system.task.gwaslab.gwaslab_genetic_corr_by_ct_ldsc_task import (
+    BinaryPhenotypeSampleInfo,
+)
 from mecfs_bio.build_system.task.pipes.composite_pipe import CompositePipe
 from mecfs_bio.build_system.task.pipes.compute_beta_pipe import ComputeBetaPipe
 from mecfs_bio.build_system.task.pipes.compute_se_pipe import ComputeSEPipe
@@ -58,4 +61,8 @@ SEROPOSITIVE_RA_STANDARD_ANALYSIS = concrete_standard_analysis_generator_no_rsid
     pre_pipe_before_rsid_assignment=_pre_gwaslab_pipe,
     pre_pipe_after_rsid_assignment=CompositePipe([ComputeBetaPipe(), ComputeSEPipe()]),
     filter_indels_in_harmonized=True,
+    phenotype_info_for_ldsc=BinaryPhenotypeSampleInfo(
+        sample_prevalence=0.5, estimated_population_prevalence=0.005
+    ),  # Sample prevalence must be set to 0.5 since we are working with effective sample sizes.
+    # Pop prevalence comes from https://pmc.ncbi.nlm.nih.gov/articles/PMC8053349/ which estimates 1% for RA in general.  Divide by 2 for a rough estimate for seropositive RA.
 )

--- a/mecfs_bio/build_system/task/gwaslab/gwaslab_snp_heritability_by_ldsc_task.py
+++ b/mecfs_bio/build_system/task/gwaslab/gwaslab_snp_heritability_by_ldsc_task.py
@@ -16,6 +16,7 @@ Chapter authors are S. Burgess, C.N. Foley and V. Zuber
 
 from pathlib import Path, PurePath
 
+import numpy as np
 import pandas as pd
 import structlog
 from attrs import frozen
@@ -44,8 +45,11 @@ from mecfs_bio.build_system.task.pipes.data_processing_pipe import DataProcessin
 from mecfs_bio.build_system.wf.base_wf import WF
 from mecfs_bio.constants.genomic_coordinate_constants import GenomeBuild
 from mecfs_bio.constants.gwaslab_constants import (
+    GWASLAB_BETA_COL,
     GWASLAB_SAMPLE_SIZE_COLUMN,
+    GWASLAB_SE_COL,
 )
+from mecfs_bio.constants.ldsc_constants import LDSC_Z_COL
 from mecfs_bio.util.type_related.unwrap import unwrap
 
 logger = structlog.get_logger()
@@ -77,6 +81,7 @@ class SNPHeritabilityByLDSCTask(Task):
         sumstats_asset = fetch(self._source_sumstats_id)
         sumstats = read_sumstats(sumstats_asset)
         sumstats.data = self.pipe.process_pandas(sumstats.data)
+        sumstats.data = _drop_variants_with_degenerate_z(sumstats.data)
         ref_id = self._ld_ref_id()
         ref_asset = fetch(ref_id)
         assert isinstance(ref_asset, DirectoryAsset)
@@ -137,6 +142,43 @@ class SNPHeritabilityByLDSCTask(Task):
             pipe=pipe,
             build=build,
         )
+
+
+def _drop_variants_with_degenerate_z(data: pd.DataFrame) -> pd.DataFrame:
+    """Drop variants whose LDSC Z score would be non-finite.
+
+    gwaslab builds the LDSC Z score as BETA / SE (or uses an existing Z column). A
+    variant with SE == 0 therefore yields an infinite Z (or NaN, when BETA is also 0,
+    as happens when a source reports an odds ratio rounded to 1.00). deCODE summary
+    statistics contain many such variants: odds ratios rounded to 1.00 give BETA == 0
+    and SE == 0, and underflowed p-values give SE == 0 with a non-zero BETA. A
+    non-finite Z makes the single-trait two-step estimator's IRWLS reweighting produce
+    a non-finite design matrix, which aborts the underlying SVD.
+
+    LDSC's own munge step drops these variants; single-trait estimate_h2_by_ldsc does
+    not (unlike the stratified path, which caps chi-square unconditionally), so we drop
+    them here rather than at the call site, since the requirement is intrinsic to this
+    regression. Variants are matched to gwaslab's Z-resolution order: prefer an existing
+    Z column, otherwise derive the finiteness requirement from BETA and SE.
+    """
+    if LDSC_Z_COL in data.columns:
+        keep = np.isfinite(data[LDSC_Z_COL])
+    elif GWASLAB_BETA_COL in data.columns and GWASLAB_SE_COL in data.columns:
+        keep = (
+            np.isfinite(data[GWASLAB_BETA_COL])
+            & np.isfinite(data[GWASLAB_SE_COL])
+            & (data[GWASLAB_SE_COL] > 0)
+        )
+    else:
+        return data
+    n_dropped = int((~keep).sum())
+    if n_dropped:
+        logger.info(
+            "Dropped variants with degenerate (non-finite) LDSC Z score",
+            n_dropped=n_dropped,
+            n_remaining=int(keep.sum()),
+        )
+    return data.loc[keep].copy()
 
 
 def _get_prev_params(phenotype_info: PhenotypeInfo) -> dict:

--- a/mecfs_bio/build_system/task/pipes/effective_n_from_cohort_string_pipe.py
+++ b/mecfs_bio/build_system/task/pipes/effective_n_from_cohort_string_pipe.py
@@ -24,6 +24,7 @@ import narwhals
 from attrs import frozen
 
 from mecfs_bio.build_system.task.pipes.data_processing_pipe import DataProcessingPipe
+from mecfs_bio.constants.gwaslab_constants import GWASLAB_SAMPLE_SIZE_COLUMN
 
 
 @frozen
@@ -56,7 +57,7 @@ class EffectiveNFromCohortStringPipe(DataProcessingPipe):
 
     cohorts: list[CohortCaseControl]
     cohort_string_col: str
-    out_col: str = "N"
+    out_col: str = GWASLAB_SAMPLE_SIZE_COLUMN
     missing_char: str = "?"
 
     def __attrs_post_init__(self) -> None:

--- a/mecfs_bio/constants/ldsc_constants.py
+++ b/mecfs_bio/constants/ldsc_constants.py
@@ -1,0 +1,1 @@
+LDSC_Z_COL = "Z"

--- a/test_mecfs_bio/unit/build_system/task/gwaslab/test_gwaslab_snp_heritability_by_ldsc_task.py
+++ b/test_mecfs_bio/unit/build_system/task/gwaslab/test_gwaslab_snp_heritability_by_ldsc_task.py
@@ -1,0 +1,60 @@
+import numpy as np
+import pandas as pd
+
+from mecfs_bio.build_system.task.gwaslab.gwaslab_snp_heritability_by_ldsc_task import (
+    _drop_variants_with_degenerate_z,
+)
+from mecfs_bio.constants.gwaslab_constants import (
+    GWASLAB_BETA_COL,
+    GWASLAB_P_COL,
+    GWASLAB_SE_COL,
+)
+from mecfs_bio.constants.ldsc_constants import LDSC_Z_COL
+
+_ID_COL = "SNP"
+
+
+def test_drops_zero_se_variants():
+    # SE == 0 with BETA == 0 (odds ratio rounded to 1.00) -> Z would be NaN;
+    # SE == 0 with BETA != 0 (underflowed p-value) -> Z would be inf.
+    data = pd.DataFrame(
+        {
+            _ID_COL: ["a", "b", "c", "d"],
+            GWASLAB_BETA_COL: [0.1, 0.0, 0.2, -0.3],
+            GWASLAB_SE_COL: [0.05, 0.0, 0.0, 0.04],
+        }
+    )
+    result = _drop_variants_with_degenerate_z(data)
+    assert result[_ID_COL].tolist() == ["a", "d"]
+
+
+def test_keeps_all_finite_se_variants():
+    data = pd.DataFrame(
+        {
+            _ID_COL: ["a", "b"],
+            GWASLAB_BETA_COL: [0.1, -0.2],
+            GWASLAB_SE_COL: [0.05, 0.03],
+        }
+    )
+    result = _drop_variants_with_degenerate_z(data)
+    assert result[_ID_COL].tolist() == ["a", "b"]
+
+
+def test_prefers_existing_z_column():
+    data = pd.DataFrame(
+        {
+            _ID_COL: ["a", "b", "c"],
+            LDSC_Z_COL: [1.5, np.inf, np.nan],
+            # BETA/SE would keep every row; the Z column must take precedence.
+            GWASLAB_BETA_COL: [0.1, 0.2, 0.3],
+            GWASLAB_SE_COL: [0.05, 0.05, 0.05],
+        }
+    )
+    result = _drop_variants_with_degenerate_z(data)
+    assert result[_ID_COL].tolist() == ["a"]
+
+
+def test_noop_without_z_or_beta_se_columns():
+    data = pd.DataFrame({_ID_COL: ["a", "b"], GWASLAB_P_COL: [0.1, 0.2]})
+    result = _drop_variants_with_degenerate_z(data)
+    assert result[_ID_COL].tolist() == ["a", "b"]


### PR DESCRIPTION
- Run LDSC analysis of seropositive RA
- Add an extra check to filter out non-finite z scores from the LDSC task.  This was necessary because the DECODE meta-gwas includes a number of SNPs with standard error of 0, which results in infinite Z scores.