### PR TITLE
Add Synapse download capability to WF via composition

### DIFF
--- a/mecfs_bio/build_system/task/get_file_from_synapse_task.py
+++ b/mecfs_bio/build_system/task/get_file_from_synapse_task.py
@@ -5,8 +5,6 @@ Task to get a file from synapse.org, a scientific data repository.
 from pathlib import Path
 
 import structlog
-import synapseclient
-import synapseutils
 from attrs import frozen
 
 from mecfs_bio.build_system.asset.base_asset import Asset
@@ -35,9 +33,6 @@ class GetFileFromSynapseTask(Task):
         return []
 
     def execute(self, scratch_dir: Path, fetch: Fetch, wf: WF) -> Asset:
-        syn = synapseclient.login()
-        files = synapseutils.syncFromSynapse(syn, self.synid, path=str(scratch_dir))
-        logger.debug(f"downloaded: {files}")
-        assert len(files) == 1
-        assert files[0].name == self.expected_filename
-        return FileAsset(Path(files[0].path))
+        path = wf.download_from_synapse(self.synid, scratch_dir, self.expected_filename)
+        logger.debug(f"downloaded: {path}")
+        return FileAsset(path)

--- a/mecfs_bio/build_system/wf/base_wf.py
+++ b/mecfs_bio/build_system/wf/base_wf.py
@@ -2,24 +2,44 @@ from abc import ABC
 from pathlib import Path
 
 import py3_wget
+from attrs import Factory, frozen
 
+from mecfs_bio.build_system.wf.synapse_downloader import (
+    SharedClientSynapseDownloader,
+    SynapseDownloader,
+)
 from mecfs_bio.util.download.robust_download import robust_download_with_aria
 from mecfs_bio.util.download.verify import verify_hash
 
 
+@frozen
 class WF(ABC):
     """
     An interface to the external world.
-    Currently only used for downloading files.
-    May be extended in the future .
+
+    External-world capabilities are composed in rather than baked into each
+    subclass: download_from_synapse delegates to a SynapseDownloader, so the
+    delivery strategy varies independently of the WF subclass and adding future
+    capabilities does not multiply subclasses. Downloading from a URL is still
+    the subclass's own concern (it is what the delivery-strategy subclasses
+    actually differ on).
     """
+
+    synapse_downloader: SynapseDownloader = Factory(SharedClientSynapseDownloader)
 
     def download_from_url(
         self, url: str, local_path: Path, md5_hash: str | None
     ) -> None:
         pass
 
+    def download_from_synapse(
+        self, synid: str, dest_dir: Path, expected_name: str
+    ) -> Path:
+        """Download the single file at synid into dest_dir and return its path."""
+        return self.synapse_downloader.download(synid, dest_dir, expected_name)
 
+
+@frozen
 class SimpleWF(WF):
     def download_from_url(
         self, url: str, local_path: Path, md5_hash: str | None
@@ -35,6 +55,7 @@ class SimpleWF(WF):
         )
 
 
+@frozen
 class RobustDownloadWF(WF):
     def download_from_url(
         self, url: str, local_path: Path, md5_hash: str | None

--- a/mecfs_bio/build_system/wf/base_wf.py
+++ b/mecfs_bio/build_system/wf/base_wf.py
@@ -16,13 +16,6 @@ from mecfs_bio.util.download.verify import verify_hash
 class WF(ABC):
     """
     An interface to the external world.
-
-    External-world capabilities are composed in rather than baked into each
-    subclass: download_from_synapse delegates to a SynapseDownloader, so the
-    delivery strategy varies independently of the WF subclass and adding future
-    capabilities does not multiply subclasses. Downloading from a URL is still
-    the subclass's own concern (it is what the delivery-strategy subclasses
-    actually differ on).
     """
 
     synapse_downloader: SynapseDownloader = Factory(SharedClientSynapseDownloader)

--- a/mecfs_bio/build_system/wf/synapse_downloader.py
+++ b/mecfs_bio/build_system/wf/synapse_downloader.py
@@ -1,11 +1,5 @@
 """
 Synapse download capability for the WF external-world interface.
-
-WF delegates download_from_synapse to a SynapseDownloader so that the delivery
-strategy (how a client is obtained and reused) is composed into WF rather than
-baked into each WF subclass. The default, SharedClientSynapseDownloader, logs in
-once and reuses the client across a run so a pipeline that pulls many Synapse
-entities does not re-authenticate per task.
 """
 
 from __future__ import annotations
@@ -13,10 +7,9 @@ from __future__ import annotations
 import threading
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    import synapseclient
+import synapseclient
+import synapseutils
 
 
 class SynapseDownloader(ABC):
@@ -29,13 +22,7 @@ class SynapseDownloader(ABC):
 
 
 class SharedClientSynapseDownloader(SynapseDownloader):
-    """Downloads via a lazily authenticated Synapse client reused across calls.
-
-    The client is created on first use behind a lock, so a run of many downloads
-    authenticates once. The lock guards lazy login only; relying on a single
-    client for concurrent syncFromSynapse calls is deferred until the scheduler
-    actually runs tasks in parallel.
-    """
+    """Downloads via a lazily authenticated Synapse client reused across calls."""
 
     def __init__(self) -> None:
         self._client: synapseclient.Synapse | None = None
@@ -44,13 +31,10 @@ class SharedClientSynapseDownloader(SynapseDownloader):
     def _client_or_login(self) -> synapseclient.Synapse:
         with self._login_lock:
             if self._client is None:
-                import synapseclient
-
                 self._client = synapseclient.login()
             return self._client
 
     def download(self, synid: str, dest_dir: Path, expected_name: str) -> Path:
-        import synapseutils
 
         files = synapseutils.syncFromSynapse(
             self._client_or_login(), synid, path=str(dest_dir)

--- a/mecfs_bio/build_system/wf/synapse_downloader.py
+++ b/mecfs_bio/build_system/wf/synapse_downloader.py
@@ -1,0 +1,60 @@
+"""
+Synapse download capability for the WF external-world interface.
+
+WF delegates download_from_synapse to a SynapseDownloader so that the delivery
+strategy (how a client is obtained and reused) is composed into WF rather than
+baked into each WF subclass. The default, SharedClientSynapseDownloader, logs in
+once and reuses the client across a run so a pipeline that pulls many Synapse
+entities does not re-authenticate per task.
+"""
+
+from __future__ import annotations
+
+import threading
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import synapseclient
+
+
+class SynapseDownloader(ABC):
+    """Downloads a single file from synapse.org into a local directory."""
+
+    @abstractmethod
+    def download(self, synid: str, dest_dir: Path, expected_name: str) -> Path:
+        """Download the single file at synid into dest_dir, assert its name equals
+        expected_name, and return its local path."""
+
+
+class SharedClientSynapseDownloader(SynapseDownloader):
+    """Downloads via a lazily authenticated Synapse client reused across calls.
+
+    The client is created on first use behind a lock, so a run of many downloads
+    authenticates once. The lock guards lazy login only; relying on a single
+    client for concurrent syncFromSynapse calls is deferred until the scheduler
+    actually runs tasks in parallel.
+    """
+
+    def __init__(self) -> None:
+        self._client: synapseclient.Synapse | None = None
+        self._login_lock = threading.Lock()
+
+    def _client_or_login(self) -> synapseclient.Synapse:
+        with self._login_lock:
+            if self._client is None:
+                import synapseclient
+
+                self._client = synapseclient.login()
+            return self._client
+
+    def download(self, synid: str, dest_dir: Path, expected_name: str) -> Path:
+        import synapseutils
+
+        files = synapseutils.syncFromSynapse(
+            self._client_or_login(), synid, path=str(dest_dir)
+        )
+        assert len(files) == 1, f"expected one file for {synid}, got {len(files)}"
+        assert files[0].name == expected_name, files[0].name
+        return Path(files[0].path)

--- a/test_mecfs_bio/unit/build_system/wf/test_synapse_downloader.py
+++ b/test_mecfs_bio/unit/build_system/wf/test_synapse_downloader.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+from mecfs_bio.build_system.wf.base_wf import RobustDownloadWF, SimpleWF
+from mecfs_bio.build_system.wf.synapse_downloader import SynapseDownloader
+
+
+class _RecordingDownloader(SynapseDownloader):
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, Path, str]] = []
+
+    def download(self, synid: str, dest_dir: Path, expected_name: str) -> Path:
+        self.calls.append((synid, dest_dir, expected_name))
+        out = dest_dir / expected_name
+        out.write_text("payload")
+        return out
+
+
+def test_wf_delegates_download_from_synapse(tmp_path: Path):
+    fake = _RecordingDownloader()
+    wf = SimpleWF(synapse_downloader=fake)
+
+    out = wf.download_from_synapse("syn123", tmp_path, "protein.tar")
+
+    assert out == tmp_path / "protein.tar"
+    assert out.read_text() == "payload"
+    assert fake.calls == [("syn123", tmp_path, "protein.tar")]
+
+
+def test_wf_subclasses_construct_with_default_downloader():
+    # Zero-arg construction must keep working; the default is the shared-client
+    # downloader, which is composed identically into both delivery strategies.
+    for wf in (SimpleWF(), RobustDownloadWF()):
+        assert isinstance(wf.synapse_downloader, SynapseDownloader)

--- a/test_mecfs_bio/unit/build_system/wf/test_synapse_downloader.py
+++ b/test_mecfs_bio/unit/build_system/wf/test_synapse_downloader.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from mecfs_bio.build_system.wf.base_wf import RobustDownloadWF, SimpleWF
+from mecfs_bio.build_system.wf.base_wf import SimpleWF
 from mecfs_bio.build_system.wf.synapse_downloader import SynapseDownloader
 
 
@@ -24,10 +24,3 @@ def test_wf_delegates_download_from_synapse(tmp_path: Path):
     assert out == tmp_path / "protein.tar"
     assert out.read_text() == "payload"
     assert fake.calls == [("syn123", tmp_path, "protein.tar")]
-
-
-def test_wf_subclasses_construct_with_default_downloader():
-    # Zero-arg construction must keep working; the default is the shared-client
-    # downloader, which is composed identically into both delivery strategies.
-    for wf in (SimpleWF(), RobustDownloadWF()):
-        assert isinstance(wf.synapse_downloader, SynapseDownloader)


### PR DESCRIPTION
- Move downloading from Synapse to `WF`.  This is consistent with the original concept of `WF` (and interface to the external world), and has advantages such as : 1) easier testing of Tasks involving Synapse downloads 2)  Share Synapse login between tasks, instead of logging in repeatedly.
- I plan to make use of this change when downloading summary statistics files from the UK Biobank Pharma Proteomics Project.