### PR TITLE
Refactor WF to use composition

### DIFF
--- a/mecfs_bio/build_system/runner/simple_runner.py
+++ b/mecfs_bio/build_system/runner/simple_runner.py
@@ -39,7 +39,8 @@ from mecfs_bio.build_system.scheduler.topological_scheduler import (
 )
 from mecfs_bio.build_system.task.base_task import Task
 from mecfs_bio.build_system.tasks.simple_tasks import find_tasks
-from mecfs_bio.build_system.wf.base_wf import RobustDownloadWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
+from mecfs_bio.build_system.wf.wf_downloader import RobustWFDownloader
 
 
 @frozen
@@ -88,8 +89,7 @@ class SimpleRunner:
         rebuilder = VerifyingTraceRebuilder(
             tracer=self.tracer, post_execute=self.post_execute
         )
-        wf = RobustDownloadWF()
-        # wf= SimpleWF()
+        wf = make_wf(downloader=RobustWFDownloader())
         meta_to_path = self.meta_to_path
         tasks = find_tasks(targets)
         must_rebuild_graph = dependees_of_targets_from_tasks(

--- a/mecfs_bio/build_system/wf/base_wf.py
+++ b/mecfs_bio/build_system/wf/base_wf.py
@@ -1,29 +1,33 @@
-from abc import ABC
 from pathlib import Path
 
-import py3_wget
-from attrs import Factory, frozen
+from attrs import frozen
 
 from mecfs_bio.build_system.wf.synapse_downloader import (
     SharedClientSynapseDownloader,
     SynapseDownloader,
 )
-from mecfs_bio.util.download.robust_download import robust_download_with_aria
-from mecfs_bio.util.download.verify import verify_hash
+from mecfs_bio.build_system.wf.wf_downloader import (
+    SimpleWFDownloader,
+    WFDownloader,
+)
 
 
 @frozen
-class WF(ABC):
+class WF:
     """
     An interface to the external world.
+
+    To add a new capability, add an attribute here and a corresponding parameter to make_wf
+    with an appropriate default.
     """
 
-    synapse_downloader: SynapseDownloader = Factory(SharedClientSynapseDownloader)
+    downloader: WFDownloader
+    synapse_downloader: SynapseDownloader
 
     def download_from_url(
         self, url: str, local_path: Path, md5_hash: str | None
     ) -> None:
-        pass
+        self.downloader.download(url, local_path, md5_hash)
 
     def download_from_synapse(
         self, synid: str, dest_dir: Path, expected_name: str
@@ -32,29 +36,16 @@ class WF(ABC):
         return self.synapse_downloader.download(synid, dest_dir, expected_name)
 
 
-@frozen
-class SimpleWF(WF):
-    def download_from_url(
-        self, url: str, local_path: Path, md5_hash: str | None
-    ) -> None:
-        # py3_wget attempts to read the whole file to check md5.  doesn't work for large files.  So implement my own check
-        py3_wget.download_file(
-            url=url,
-            output_path=local_path,
-        )
-        verify_hash(
-            downloaded_file=local_path,
-            expected_hash=md5_hash,
-        )
-
-
-@frozen
-class RobustDownloadWF(WF):
-    def download_from_url(
-        self, url: str, local_path: Path, md5_hash: str | None
-    ) -> None:
-        robust_download_with_aria(
-            md5sum=md5_hash,
-            url=url,
-            dest=local_path,
-        )
+def make_wf(
+    downloader: WFDownloader | None = None,
+    synapse_downloader: SynapseDownloader | None = None,
+) -> WF:
+    """Construct a WF, defaulting any capability not explicitly supplied."""
+    return WF(
+        downloader=downloader if downloader is not None else SimpleWFDownloader(),
+        synapse_downloader=(
+            synapse_downloader
+            if synapse_downloader is not None
+            else SharedClientSynapseDownloader()
+        ),
+    )

--- a/mecfs_bio/build_system/wf/synapse_downloader.py
+++ b/mecfs_bio/build_system/wf/synapse_downloader.py
@@ -1,5 +1,5 @@
 """
-Synapse download capability for the WF external-world interface.
+Synapse download capability
 """
 
 from __future__ import annotations

--- a/mecfs_bio/build_system/wf/wf_downloader.py
+++ b/mecfs_bio/build_system/wf/wf_downloader.py
@@ -1,0 +1,45 @@
+"""
+URL download capability
+"""
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+import py3_wget
+
+from mecfs_bio.util.download.robust_download import robust_download_with_aria
+from mecfs_bio.util.download.verify import verify_hash
+
+
+class WFDownloader(ABC):
+    """Downloads the file at a URL to a local path, verifying its md5 hash."""
+
+    @abstractmethod
+    def download(self, url: str, local_path: Path, md5_hash: str | None) -> None:
+        """Download the file at url into local_path and verify its md5 hash."""
+
+
+class SimpleWFDownloader(WFDownloader):
+    """Downloads via py3_wget, then verifies the hash separately."""
+
+    def download(self, url: str, local_path: Path, md5_hash: str | None) -> None:
+        # py3_wget attempts to read the whole file to check md5.  doesn't work for large files.  So implement my own check
+        py3_wget.download_file(
+            url=url,
+            output_path=local_path,
+        )
+        verify_hash(
+            downloaded_file=local_path,
+            expected_hash=md5_hash,
+        )
+
+
+class RobustWFDownloader(WFDownloader):
+    """Downloads via aria2 with retries, suitable for large files."""
+
+    def download(self, url: str, local_path: Path, md5_hash: str | None) -> None:
+        robust_download_with_aria(
+            md5sum=md5_hash,
+            url=url,
+            dest=local_path,
+        )

--- a/test_mecfs_bio/unit/build_system/scheduler/test_topological_scheduler.py
+++ b/test_mecfs_bio/unit/build_system/scheduler/test_topological_scheduler.py
@@ -36,7 +36,7 @@ from mecfs_bio.build_system.task.discard_deps_task_wrapper import (
 from mecfs_bio.build_system.task.external_file_copy_task import ExternalFileCopyTask
 from mecfs_bio.build_system.task.failing_task import FailingTask
 from mecfs_bio.build_system.tasks.simple_tasks import find_tasks
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 
 #
 
@@ -84,7 +84,7 @@ def test_file_copying_task(tmp_path: Path, tracer: Tracer) -> None:
 
     tasks = find_tasks([task3])
 
-    wf = SimpleWF()
+    wf = make_wf()
     info: VerifyingTraceInfo = VerifyingTraceInfo.empty()
 
     asset_dir = tmp_path / "asset_dir"
@@ -291,7 +291,7 @@ def test_incremental_save_with_failing_task(tmp_path: Path) -> None:
 
     tasks = find_tasks([task2])
 
-    wf = SimpleWF()
+    wf = make_wf()
     info: VerifyingTraceInfo = VerifyingTraceInfo.empty()
 
     asset_dir = tmp_path / "asset_dir"

--- a/test_mecfs_bio/unit/build_system/task/gwaslab/test_gwaslab_create_sumstats_task.py
+++ b/test_mecfs_bio/unit/build_system/task/gwaslab/test_gwaslab_create_sumstats_task.py
@@ -23,7 +23,7 @@ from mecfs_bio.build_system.task.gwaslab.gwaslab_create_sumstats_task import (
 from mecfs_bio.build_system.task.gwaslab.gwaslab_sumstats_to_table_task import (
     GwasLabSumstatsToTableTask,
 )
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 from mecfs_bio.constants.gwaslab_constants import GWASLAB_STATUS_COL
 
 
@@ -52,7 +52,7 @@ def test_gwaslab_sumstats(
             Path("test_mecfs_bio/unit/build_system/task/dummy_data.regenie")
         )
 
-    asset_result = task.execute(scratch_dir=scratch_loc, fetch=fetch, wf=SimpleWF())
+    asset_result = task.execute(scratch_dir=scratch_loc, fetch=fetch, wf=make_wf())
     with open(asset_result.path, "rb") as f:
         loaded = pickle.load(
             f,
@@ -72,7 +72,7 @@ def test_gwaslab_sumstats(
     task_2 = GwasLabSumstatsToTableTask.create_from_source_task(
         source_tsk=task, asset_id="table_task", sub_dir="processed"
     )
-    asset_2 = task_2.execute(scratch_dir=scratch_loc_2, wf=SimpleWF(), fetch=fetch_2)
+    asset_2 = task_2.execute(scratch_dir=scratch_loc_2, wf=make_wf(), fetch=fetch_2)
     scan_dataframe_asset(asset=asset_2, meta=task_2.meta)
 
 

--- a/test_mecfs_bio/unit/build_system/task/gwaslab/test_sldsc_scatter_plot_task.py
+++ b/test_mecfs_bio/unit/build_system/task/gwaslab/test_sldsc_scatter_plot_task.py
@@ -16,7 +16,7 @@ from mecfs_bio.build_system.task.fake_task import FakeTask
 from mecfs_bio.build_system.task.gwaslab.sldsc_scatter_plot_task import (
     SLDSCScatterPlotTask,
 )
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 
 _dummy_data = {
     "Name": {
@@ -353,5 +353,5 @@ def test_sldsc_scatter(tmp_path: Path):
             return FileAsset(df_loc)
         raise ValueError("unknown asset id")
 
-    result = task.execute(scratch_dir=scratch_loc, fetch=fetch, wf=SimpleWF())
+    result = task.execute(scratch_dir=scratch_loc, fetch=fetch, wf=make_wf())
     assert isinstance(result, DirectoryAsset)

--- a/test_mecfs_bio/unit/build_system/task/lcv/test_lcv_clustermap_plot.py
+++ b/test_mecfs_bio/unit/build_system/task/lcv/test_lcv_clustermap_plot.py
@@ -26,7 +26,7 @@ from mecfs_bio.build_system.task.lcv.lcv_task import (
     UPSTREAM_TRAIT_COL,
 )
 from mecfs_bio.build_system.task.xr_pipes.xr_identity import XRIdentityPipe
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 
 
 def test_lcv_clustermap(tmp_path: Path):
@@ -69,7 +69,7 @@ def test_lcv_clustermap(tmp_path: Path):
             return FileAsset(df_loc)
         raise NotImplementedError()
 
-    result = task.execute(scratch_dir=scratch_loc, fetch=fetch, wf=SimpleWF())
+    result = task.execute(scratch_dir=scratch_loc, fetch=fetch, wf=make_wf())
     assert isinstance(result, FileAsset)
     assert result.path.exists()
     assert result.path.stat().st_size > 0

--- a/test_mecfs_bio/unit/build_system/task/magma/test_magma_forward_stepwise_select_task.py
+++ b/test_mecfs_bio/unit/build_system/task/magma/test_magma_forward_stepwise_select_task.py
@@ -20,7 +20,7 @@ from mecfs_bio.build_system.task.magma.magma_forward_stepwise_select_task import
 from mecfs_bio.build_system.task.magma.magma_gene_set_analysis_task import (
     GENE_SET_ANALYSIS_OUTPUT_STEM_NAME,
 )
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 from mecfs_bio.constants.magma_constants import (
     MAGMA_MODEL_COLUMN,
     MAGMA_P_COLUMN,
@@ -81,7 +81,7 @@ def test_forward_stepwise_when_missing_data(tmp_path: Path):
             return DirectoryAsset(conf_dir_path)
         raise ValueError("Unknown asset id")
 
-    result = tsk.execute(fetch=fetch, scratch_dir=scratch, wf=SimpleWF())
+    result = tsk.execute(fetch=fetch, scratch_dir=scratch, wf=make_wf())
     assert isinstance(result, FileAsset)
     result_df = pd.read_csv(result.path)
     assert len(result_df) == 0
@@ -136,7 +136,7 @@ def test_forward_stepwise_single_significant_cluster(tmp_path: Path):
             return DirectoryAsset(cond_dir_path)
         raise ValueError("Unknown asset id")
 
-    result = tsk.execute(fetch=fetch, scratch_dir=scratch, wf=SimpleWF())
+    result = tsk.execute(fetch=fetch, scratch_dir=scratch, wf=make_wf())
     assert isinstance(result, FileAsset)
     result_df = pd.read_csv(result.path)
     assert result_df[RETAINED_CLUSTERS_COLUMN].tolist() == ["Cluster1"]

--- a/test_mecfs_bio/unit/build_system/task/magma/test_magma_gene_set_analysis_task.py
+++ b/test_mecfs_bio/unit/build_system/task/magma/test_magma_gene_set_analysis_task.py
@@ -14,7 +14,7 @@ from mecfs_bio.build_system.task.magma.magma_gene_set_analysis_task import (
     MagmaGeneSetAnalysisTask,
     ModelParams,
 )
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 
 _dummy_spec_data_1 = """GENE
 1
@@ -69,6 +69,6 @@ def test_gene_set_analysis_empty_gene_sets(
             )
 
     result = gene_set_covar_analysis_task.execute(
-        scratch_dir=scratch, fetch=fetch, wf=SimpleWF()
+        scratch_dir=scratch, fetch=fetch, wf=make_wf()
     )
     assert isinstance(result, DirectoryAsset)

--- a/test_mecfs_bio/unit/build_system/task/magma/test_magma_per_variant_sample_size.py
+++ b/test_mecfs_bio/unit/build_system/task/magma/test_magma_per_variant_sample_size.py
@@ -26,7 +26,7 @@ from mecfs_bio.build_system.scheduler.topological_scheduler import topological
 from mecfs_bio.build_system.task.base_task import Task
 from mecfs_bio.build_system.task.magma.magma_snp_location_task import MagmaSNPFileTask
 from mecfs_bio.build_system.tasks.simple_tasks import find_tasks
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 from mecfs_bio.constants.gwaslab_constants import (
     GWASLAB_P_COL,
     GWASLAB_RSID_COL,
@@ -55,7 +55,7 @@ def test_pval_file_includes_n_column(tmp_path: Path, assign_rsids_task: Task):
         rebuilder=rebuilder,
         tasks=tasks,
         targets=[p_value_task.meta.asset_id],
-        wf=SimpleWF(),
+        wf=make_wf(),
         info=VerifyingTraceInfo.empty(),
         meta_to_path=SimpleMetaToPath(root=asset_dir),
     )

--- a/test_mecfs_bio/unit/build_system/task/magma/test_prepare_gene_sets_for_magma_task.py
+++ b/test_mecfs_bio/unit/build_system/task/magma/test_prepare_gene_sets_for_magma_task.py
@@ -15,7 +15,7 @@ from mecfs_bio.build_system.task.fake_task import FakeTask
 from mecfs_bio.build_system.task.magma.prepare_gene_sets_for_magma_task import (
     PrepareGeneSetsForMagmaTask,
 )
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 from mecfs_bio.constants.magma_constants import MAGMA_GENE_COL
 from mecfs_bio.constants.msigdb_columns import (
     EXACT_SOURCE,
@@ -87,7 +87,7 @@ def test_output_is_tab_separated_with_gene_column(tmp_path: Path):
     )
     scratch = tmp_path / "scratch"
     scratch.mkdir()
-    result = task.execute(scratch, _FileFetch(db_path), SimpleWF())
+    result = task.execute(scratch, _FileFetch(db_path), make_wf())
 
     assert isinstance(result, FileAsset)
     df = pd.read_csv(result.path, sep="\t")
@@ -105,7 +105,7 @@ def test_gene_column_contains_entrez_ids(tmp_path: Path):
     )
     scratch = tmp_path / "scratch"
     scratch.mkdir()
-    result = task.execute(scratch, _FileFetch(db_path), SimpleWF())
+    result = task.execute(scratch, _FileFetch(db_path), make_wf())
 
     assert isinstance(result, FileAsset)
     df = pd.read_csv(result.path, sep="\t")
@@ -122,7 +122,7 @@ def test_binary_indicators_are_correct(tmp_path: Path):
     )
     scratch = tmp_path / "scratch"
     scratch.mkdir()
-    result = task.execute(scratch, _FileFetch(db_path), SimpleWF())
+    result = task.execute(scratch, _FileFetch(db_path), make_wf())
 
     assert isinstance(result, FileAsset)
     df = pd.read_csv(result.path, sep="\t").set_index(MAGMA_GENE_COL)
@@ -146,7 +146,7 @@ def test_genes_are_union_across_all_sets(tmp_path: Path):
     )
     scratch = tmp_path / "scratch"
     scratch.mkdir()
-    result = task.execute(scratch, _FileFetch(db_path), SimpleWF())
+    result = task.execute(scratch, _FileFetch(db_path), make_wf())
 
     assert isinstance(result, FileAsset)
     df = pd.read_csv(result.path, sep="\t")
@@ -162,7 +162,7 @@ def test_values_are_only_zero_or_one(tmp_path: Path):
     )
     scratch = tmp_path / "scratch"
     scratch.mkdir()
-    result = task.execute(scratch, _FileFetch(db_path), SimpleWF())
+    result = task.execute(scratch, _FileFetch(db_path), make_wf())
 
     assert isinstance(result, FileAsset)
     df = pd.read_csv(result.path, sep="\t")
@@ -199,7 +199,7 @@ def test_unknown_gene_set_raises(tmp_path: Path):
     scratch = tmp_path / "scratch"
     scratch.mkdir()
     with pytest.raises(ValueError, match="NONEXISTENT"):
-        task.execute(scratch, _FileFetch(db_path), SimpleWF())
+        task.execute(scratch, _FileFetch(db_path), make_wf())
 
 
 def test_none_ncbi_ids_are_dropped(tmp_path: Path):
@@ -217,7 +217,7 @@ def test_none_ncbi_ids_are_dropped(tmp_path: Path):
     )
     scratch = tmp_path / "scratch"
     scratch.mkdir()
-    result = task.execute(scratch, _FileFetch(db_path), SimpleWF())
+    result = task.execute(scratch, _FileFetch(db_path), make_wf())
 
     assert isinstance(result, FileAsset)
     df = pd.read_csv(result.path, sep="\t")
@@ -231,7 +231,7 @@ def test_genes_outside_selected_sets_are_included(tmp_path: Path):
     )
     scratch = tmp_path / "scratch"
     scratch.mkdir()
-    result = task.execute(scratch, _FileFetch(db_path), SimpleWF())
+    result = task.execute(scratch, _FileFetch(db_path), make_wf())
 
     assert isinstance(result, FileAsset)
     df = pd.read_csv(result.path, sep="\t").set_index(MAGMA_GENE_COL)

--- a/test_mecfs_bio/unit/build_system/task/test_assign_rsids_via_snp_task.py
+++ b/test_mecfs_bio/unit/build_system/task/test_assign_rsids_via_snp_task.py
@@ -18,7 +18,7 @@ from mecfs_bio.build_system.rebuilder.verifying_trace_rebuilder.verifying_trace_
 from mecfs_bio.build_system.scheduler.topological_scheduler import topological
 from mecfs_bio.build_system.task.base_task import Task
 from mecfs_bio.build_system.tasks.simple_tasks import find_tasks
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 from mecfs_bio.constants.gwaslab_constants import GWASLAB_RSID_COL
 
 # from test_mecfs_bio.unit.build_system.task.conftest import parquet_snp151, dummy_processed_gwas_parquet
@@ -29,7 +29,7 @@ def test_assign_rsids_via_snp_task(tmp_path: Path, assign_rsids_task: Task):
 
     tasks = find_tasks([task3])
 
-    wf = SimpleWF()
+    wf = make_wf()
     info: VerifyingTraceInfo = VerifyingTraceInfo.empty()
 
     asset_dir = tmp_path / "asset_dir"

--- a/test_mecfs_bio/unit/build_system/task/test_combine_gene_lists.py
+++ b/test_mecfs_bio/unit/build_system/task/test_combine_gene_lists.py
@@ -15,7 +15,7 @@ from mecfs_bio.build_system.task.combine_gene_lists_task import (
     SrcGeneList,
 )
 from mecfs_bio.build_system.task.fake_task import FakeTask
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 
 
 def test_combine_gene_lists(tmp_path: Path):
@@ -60,7 +60,7 @@ def test_combine_gene_lists(tmp_path: Path):
             return FileAsset(df_2_loc)
         raise ValueError(f"unknown asset id {asset_id}")
 
-    result = task.execute(scratch_dir=scratch_loc, fetch=fetch, wf=SimpleWF())
+    result = task.execute(scratch_dir=scratch_loc, fetch=fetch, wf=make_wf())
     assert isinstance(result, FileAsset)
     result_df = pd.read_csv(result.path)
     assert len(result_df) == 4

--- a/test_mecfs_bio/unit/build_system/task/test_compressed_csv_to_parquet_task.py
+++ b/test_mecfs_bio/unit/build_system/task/test_compressed_csv_to_parquet_task.py
@@ -22,7 +22,7 @@ from mecfs_bio.build_system.task.compressed_csv_to_parquet_task import (
     CompressedCSVToParquetTask,
 )
 from mecfs_bio.build_system.task.fake_task import FakeTask
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 
 
 def _gzip_file(src: Path, target: Path):
@@ -61,6 +61,6 @@ def test_compressed_csv_to_parquet_task(tmp_path: Path):
         def __call__(self, asset_id: AssetId) -> Asset:
             return FileAsset(gzip_loc)
 
-    result = task.execute(scratch_dir=scratch_dir, fetch=MyFetch(), wf=SimpleWF())
+    result = task.execute(scratch_dir=scratch_dir, fetch=MyFetch(), wf=make_wf())
     assert isinstance(result, FileAsset)
     pd.read_parquet(result.path)

--- a/test_mecfs_bio/unit/build_system/task/test_concat_frames_in_dir_task.py
+++ b/test_mecfs_bio/unit/build_system/task/test_concat_frames_in_dir_task.py
@@ -13,7 +13,7 @@ from mecfs_bio.build_system.meta.read_spec.dataframe_read_spec import (
 from mecfs_bio.build_system.meta.simple_file_meta import SimpleFileMeta
 from mecfs_bio.build_system.task.concat_frames_in_dir_task import ConcatFramesInDirTask
 from mecfs_bio.build_system.task.fake_task import FakeTask
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 
 
 def test_concat_frames_in_dir_task(tmp_path: Path):
@@ -44,7 +44,7 @@ def test_concat_frames_in_dir_task(tmp_path: Path):
             return DirectoryAsset(subdir)
         raise ValueError("unknown asset id")
 
-    result = task.execute(scratch_dir=scratch_loc, fetch=fetch, wf=SimpleWF())
+    result = task.execute(scratch_dir=scratch_loc, fetch=fetch, wf=make_wf())
     assert isinstance(result, FileAsset)
     result_df = pd.read_parquet(result.path)
     assert len(result_df) == 6

--- a/test_mecfs_bio/unit/build_system/task/test_concat_frames_task.py
+++ b/test_mecfs_bio/unit/build_system/task/test_concat_frames_task.py
@@ -13,7 +13,7 @@ from mecfs_bio.build_system.meta.simple_file_meta import SimpleFileMeta
 from mecfs_bio.build_system.task.concat_frames_task import ConcatFramesTask
 from mecfs_bio.build_system.task.fake_task import FakeTask
 from mecfs_bio.build_system.task.pipe_dataframe_task import ParquetOutFormat
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 
 
 def test_concat_frames_in_dir_task(tmp_path: Path):
@@ -52,7 +52,7 @@ def test_concat_frames_in_dir_task(tmp_path: Path):
             return FileAsset(df_2_loc)
         raise ValueError("unknown asset id")
 
-    result = task.execute(scratch_dir=scratch_loc, fetch=fetch, wf=SimpleWF())
+    result = task.execute(scratch_dir=scratch_loc, fetch=fetch, wf=make_wf())
     assert isinstance(result, FileAsset)
     result_df = pd.read_parquet(result.path)
     assert len(result_df) == 6

--- a/test_mecfs_bio/unit/build_system/task/test_consolidate_ld_scores_task.py
+++ b/test_mecfs_bio/unit/build_system/task/test_consolidate_ld_scores_task.py
@@ -18,7 +18,7 @@ from mecfs_bio.build_system.task.consolidate_ld_scores_task import (
     ConsolidateLDScoresTask,
 )
 from mecfs_bio.build_system.task.fake_task import FakeTask
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 
 
 def _write_ld_score_gz(path: Path, rows: list[tuple[int, str, int, float]]):
@@ -67,7 +67,7 @@ def test_consolidate_ld_scores(tmp_path: Path):
     scratch_dir = tmp_path / "scratch"
     scratch_dir.mkdir()
 
-    result = tsk.execute(scratch_dir=scratch_dir, fetch=fetch, wf=SimpleWF())
+    result = tsk.execute(scratch_dir=scratch_dir, fetch=fetch, wf=make_wf())
     assert isinstance(result, FileAsset)
 
     df = pl.read_parquet(result.path)

--- a/test_mecfs_bio/unit/build_system/task/test_convert_dataframe_to_markdown_task.py
+++ b/test_mecfs_bio/unit/build_system/task/test_convert_dataframe_to_markdown_task.py
@@ -14,7 +14,7 @@ from mecfs_bio.build_system.task.convert_dataframe_to_markdown_task import (
     ConvertDataFrameToMarkdownTask,
 )
 from mecfs_bio.build_system.task.fake_task import FakeTask
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 
 
 def test_convert_dataframe_to_markdown_task(tmp_path: Path):
@@ -36,6 +36,6 @@ def test_convert_dataframe_to_markdown_task(tmp_path: Path):
     def fetch(asset_id: AssetId) -> Asset:
         return FileAsset(df_1_loc)
 
-    result = task.execute(scratch_dir=scratch_loc, fetch=fetch, wf=SimpleWF())
+    result = task.execute(scratch_dir=scratch_loc, fetch=fetch, wf=make_wf())
     assert isinstance(result, FileAsset)
     assert result.path.is_file()

--- a/test_mecfs_bio/unit/build_system/task/test_copy_file_from_directory_task.py
+++ b/test_mecfs_bio/unit/build_system/task/test_copy_file_from_directory_task.py
@@ -12,7 +12,7 @@ from mecfs_bio.build_system.task.copy_file_from_directory_task import (
     CopyFileFromDirectoryTask,
 )
 from mecfs_bio.build_system.task.fake_task import FakeTask
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 
 
 def test_copy_file_from_directory_task(tmp_path: Path):
@@ -40,5 +40,5 @@ def test_copy_file_from_directory_task(tmp_path: Path):
     def fetch(asset_id: AssetId) -> Asset:
         return DirectoryAsset(source_dir)
 
-    result = tsk.execute(scratch_dir=scratch_dir, fetch=fetch, wf=SimpleWF())
+    result = tsk.execute(scratch_dir=scratch_dir, fetch=fetch, wf=make_wf())
     assert isinstance(result, FileAsset)

--- a/test_mecfs_bio/unit/build_system/task/test_copy_files_into_directory_task.py
+++ b/test_mecfs_bio/unit/build_system/task/test_copy_files_into_directory_task.py
@@ -10,7 +10,7 @@ from mecfs_bio.build_system.task.copy_files_into_directory_task import (
     CopySource,
 )
 from mecfs_bio.build_system.task.fake_task import FakeTask
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 
 
 def test_copy_files(tmp_path: Path):
@@ -39,7 +39,7 @@ def test_copy_files(tmp_path: Path):
             return FileAsset(file_2_loc)
         raise ValueError("Invalid asset_id")
 
-    result = tsk.execute(scratch_dir=scratch_dir, fetch=fetch, wf=SimpleWF())
+    result = tsk.execute(scratch_dir=scratch_dir, fetch=fetch, wf=make_wf())
     assert isinstance(result, DirectoryAsset)
     assert (result.path / file_1_in_dir_name).exists()
     assert (result.path / file_2_in_dir_name).exists()

--- a/test_mecfs_bio/unit/build_system/task/test_download_file_Task.py
+++ b/test_mecfs_bio/unit/build_system/task/test_download_file_Task.py
@@ -11,17 +11,16 @@ from mecfs_bio.build_system.meta.simple_file_meta import SimpleFileMeta
 from mecfs_bio.build_system.task.download_file_task import (
     DownloadFileTask,
 )
-from mecfs_bio.build_system.wf.base_wf import WF
+from mecfs_bio.build_system.wf.base_wf import make_wf
+from mecfs_bio.build_system.wf.wf_downloader import WFDownloader
 from mecfs_bio.util.download.verify import calc_md5_checksum, head_file, verify_hash
 
 
 @frozen
-class FakeWF(WF):
+class FakeWFDownloader(WFDownloader):
     source_file: Path
 
-    def download_from_url(
-        self, url: str, local_path: Path, md5_hash: str | None
-    ) -> None:
+    def download(self, url: str, local_path: Path, md5_hash: str | None) -> None:
         shutil.copyfile(self.source_file, local_path)
         verify_hash(
             downloaded_file=local_path,
@@ -37,7 +36,7 @@ def test_md5_check_passes_fails_appropriately(tmp_path: Path):
     external_file_path.parent.mkdir(parents=True, exist_ok=True)
     external_file_path.write_text("yoyoyoy")
     hash_of_file = calc_md5_checksum(external_file_path)
-    wf = FakeWF(source_file=external_file_path)
+    wf = make_wf(downloader=FakeWFDownloader(source_file=external_file_path))
     scratch = tmp_path / "scratch"
     scratch.mkdir(parents=True, exist_ok=True)
     tsk_1 = DownloadFileTask(

--- a/test_mecfs_bio/unit/build_system/task/test_exract_tar_gzip_task.py
+++ b/test_mecfs_bio/unit/build_system/task/test_exract_tar_gzip_task.py
@@ -14,7 +14,7 @@ from mecfs_bio.build_system.task.extract_tar_gzip_task import (
     ReadMode,
 )
 from mecfs_bio.build_system.task.fake_task import FakeTask
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 
 WriteMode = Literal["w:gz", "w"]
 
@@ -56,7 +56,7 @@ def test_extract_tar_gzip_task(
     def fetch(asset_id: AssetId) -> Asset:
         return FileAsset(tar_loc)
 
-    result = tsk.execute(scratch_dir=scratch_dir, fetch=fetch, wf=SimpleWF())
+    result = tsk.execute(scratch_dir=scratch_dir, fetch=fetch, wf=make_wf())
     assert result.path == scratch_dir
     dir_contents = list(scratch_dir.glob("*"))
     print(dir_contents)

--- a/test_mecfs_bio/unit/build_system/task/test_extract_all_from_zip_task.py
+++ b/test_mecfs_bio/unit/build_system/task/test_extract_all_from_zip_task.py
@@ -9,7 +9,7 @@ from mecfs_bio.build_system.meta.simple_directory_meta import SimpleDirectoryMet
 from mecfs_bio.build_system.meta.simple_file_meta import SimpleFileMeta
 from mecfs_bio.build_system.task.extract_all_from_zip_task import ExtractAllFromZipTask
 from mecfs_bio.build_system.task.fake_task import FakeTask
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 
 
 def test_extract_all_zip(tmp_path: Path):
@@ -28,6 +28,6 @@ def test_extract_all_zip(tmp_path: Path):
     def fetch(asset_id: AssetId) -> Asset:
         return FileAsset(source_zip_path)
 
-    result = tsk.execute(scratch_dir=scratch_dir, fetch=fetch, wf=SimpleWF())
+    result = tsk.execute(scratch_dir=scratch_dir, fetch=fetch, wf=make_wf())
     assert isinstance(result, DirectoryAsset)
     assert len(list(result.path.iterdir())) == 2

--- a/test_mecfs_bio/unit/build_system/task/test_extract_sheet_fron_excel_file.py
+++ b/test_mecfs_bio/unit/build_system/task/test_extract_sheet_fron_excel_file.py
@@ -11,7 +11,7 @@ from mecfs_bio.build_system.task.extract_sheet_from_excel_file_task import (
 )
 from mecfs_bio.build_system.task.fake_task import FakeTask
 from mecfs_bio.build_system.task.pipe_dataframe_task import ParquetOutFormat
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 
 
 def test_extract_sheet_from_excel_file_task(tmp_path: Path):
@@ -36,7 +36,7 @@ def test_extract_sheet_from_excel_file_task(tmp_path: Path):
     def fetch(asset_id: AssetId) -> Asset:
         return FileAsset(source_excel_file_path)
 
-    result = tsk.execute(scratch_dir=scratch_dir, fetch=fetch, wf=SimpleWF())
+    result = tsk.execute(scratch_dir=scratch_dir, fetch=fetch, wf=make_wf())
     assert isinstance(result, FileAsset)
     result_df = pd.read_parquet(result.path)
     pd.testing.assert_frame_equal(dummy_data, result_df)

--- a/test_mecfs_bio/unit/build_system/task/test_extraction_from_zip_task.py
+++ b/test_mecfs_bio/unit/build_system/task/test_extraction_from_zip_task.py
@@ -13,7 +13,7 @@ from mecfs_bio.build_system.task.fake_task import FakeTask
 from mecfs_bio.build_system.task.make_executable_wrapper_task import (
     MakeExecutableWrapperTask,
 )
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 
 
 def test_extract_from_zip_and_make_executable(tmp_path: Path):
@@ -33,7 +33,7 @@ def test_extract_from_zip_and_make_executable(tmp_path: Path):
     def fetch(asset_id: AssetId) -> Asset:
         return FileAsset(source_zip_path)
 
-    result = tsk.execute(scratch_dir=scratch_dir, fetch=fetch, wf=SimpleWF())
+    result = tsk.execute(scratch_dir=scratch_dir, fetch=fetch, wf=make_wf())
     assert isinstance(result, FileAsset)
     assert result.path == scratch_dir / name_in_archive
     assert os.access(result.path, os.X_OK)

--- a/test_mecfs_bio/unit/build_system/task/test_filter_multiple_testing_table_task.py
+++ b/test_mecfs_bio/unit/build_system/task/test_filter_multiple_testing_table_task.py
@@ -16,7 +16,7 @@ from mecfs_bio.build_system.task.multiple_testing_table_task import (
     Method,
     MultipleTestingTableTask,
 )
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 
 _dummy_df = pd.DataFrame({"p": [0.02, 0.02, 1, 1, 1]})
 
@@ -48,7 +48,7 @@ def test_multiple_testing(tmp_path: Path, procedure: Method, expected_passed: in
     def fetch(asset_id: AssetId) -> Asset:
         return FileAsset(input_path)
 
-    result = tsk.execute(scratch_dir=scratch_dir, fetch=fetch, wf=SimpleWF())
+    result = tsk.execute(scratch_dir=scratch_dir, fetch=fetch, wf=make_wf())
     assert isinstance(result, FileAsset)
     result_df = pd.read_csv(result.path)
     assert len(result_df) == expected_passed

--- a/test_mecfs_bio/unit/build_system/task/test_filter_snps_by_frequency_task.py
+++ b/test_mecfs_bio/unit/build_system/task/test_filter_snps_by_frequency_task.py
@@ -15,7 +15,7 @@ from mecfs_bio.build_system.task.fake_task import FakeTask
 from mecfs_bio.build_system.task.filter_snps_by_frequency import (
     FilterSNPsFrequencyTask,
 )
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 
 
 def test_filter_snps_by_frequency_task(tmp_path: Path):
@@ -57,7 +57,7 @@ def test_filter_snps_by_frequency_task(tmp_path: Path):
     def fetch(asset_id: AssetId) -> Asset:
         return FileAsset(df_1_loc)
 
-    result = task.execute(scratch_dir=scratch_loc, fetch=fetch, wf=SimpleWF())
+    result = task.execute(scratch_dir=scratch_loc, fetch=fetch, wf=make_wf())
     assert isinstance(result, FileAsset)
     assert result.path.is_file()
 
@@ -102,4 +102,4 @@ def test_filter_snps_by_frequency_rejects_percentage_frequencies(tmp_path: Path)
         return FileAsset(df_loc)
 
     with pytest.raises(AssertionError):
-        task.execute(scratch_dir=scratch_loc, fetch=fetch, wf=SimpleWF())
+        task.execute(scratch_dir=scratch_loc, fetch=fetch, wf=make_wf())

--- a/test_mecfs_bio/unit/build_system/task/test_fixed_effect_meta_analysis_task.py
+++ b/test_mecfs_bio/unit/build_system/task/test_fixed_effect_meta_analysis_task.py
@@ -17,7 +17,7 @@ from mecfs_bio.build_system.task.fixed_effect_meta_analysis_task import (
     FixedEffectsMetaAnalysisTask,
     GwasSource,
 )
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 from mecfs_bio.constants.gwaslab_constants import (
     GWASLAB_BETA_COL,
     GWASLAB_CHROM_COL,
@@ -76,7 +76,7 @@ def _run_two_source_task(
     def fetch(asset_id: AssetId) -> Asset:
         return FileAsset(paths[str(asset_id)])
 
-    result = task.execute(scratch_dir=scratch, fetch=fetch, wf=SimpleWF())
+    result = task.execute(scratch_dir=scratch, fetch=fetch, wf=make_wf())
     assert isinstance(result, FileAsset)
     return pd.read_parquet(result.path)
 
@@ -176,7 +176,7 @@ def test_fixed_effect_meta_analysis_task(tmp_path: Path):
             return FileAsset(df_3_path)
         raise ValueError("unknown asset id")
 
-    result = task.execute(scratch_dir=scratch, fetch=fetch, wf=SimpleWF())
+    result = task.execute(scratch_dir=scratch, fetch=fetch, wf=make_wf())
     assert isinstance(result, FileAsset)
     df = pd.read_parquet(result.path)
     assert df["SE"].item() == pytest.approx(0.2235, abs=0.01)

--- a/test_mecfs_bio/unit/build_system/task/test_genetic_correlation_clustermap_plot.py
+++ b/test_mecfs_bio/unit/build_system/task/test_genetic_correlation_clustermap_plot.py
@@ -19,7 +19,7 @@ from mecfs_bio.build_system.task.genetic_correlation_clustermap_task import (
 from mecfs_bio.build_system.task.xr_pipes.xr_identity import (
     XRIdentityPipe,
 )
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 
 
 def test_genetic_correlation_clustermap(tmp_path: Path):
@@ -56,5 +56,5 @@ def test_genetic_correlation_clustermap(tmp_path: Path):
             return FileAsset(df_loc)
         raise NotImplementedError()
 
-    result = task.execute(scratch_dir=scratch_loc, fetch=fetch, wf=SimpleWF())
+    result = task.execute(scratch_dir=scratch_loc, fetch=fetch, wf=make_wf())
     assert isinstance(result, FileAsset)

--- a/test_mecfs_bio/unit/build_system/task/test_harmonize_gwas_with_reference_via_chrom_pos_alleles.py
+++ b/test_mecfs_bio/unit/build_system/task/test_harmonize_gwas_with_reference_via_chrom_pos_alleles.py
@@ -14,7 +14,7 @@ from mecfs_bio.build_system.task.fake_task import FakeTask
 from mecfs_bio.build_system.task.harmonize_gwas_with_reference_table_via_chrom_pos_alleles import (
     HarmonizeGWASWithReferenceViaAlleles,
 )
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 from mecfs_bio.constants.gwaslab_constants import (
     GWASLAB_BETA_COL,
     GWASLAB_CHROM_COL,
@@ -151,7 +151,7 @@ def test_harmonize_gwas_with_reference_via_chrom_pos_alleles(tmp_path: Path):
             return FileAsset(reference_path)
         raise ValueError(f"Unknown asset {asset_id}")
 
-    result = tsk.execute(scratch_dir=scratch_dir, fetch=fetch, wf=SimpleWF())
+    result = tsk.execute(scratch_dir=scratch_dir, fetch=fetch, wf=make_wf())
     assert isinstance(result, FileAsset)
     result_df = pd.read_parquet(result.path)
     assert set(result_df[GWASLAB_RSID_COL].tolist()) == {"rs100", "rs300"}

--- a/test_mecfs_bio/unit/build_system/task/test_harmonize_gwas_with_reference_via_rsid.py
+++ b/test_mecfs_bio/unit/build_system/task/test_harmonize_gwas_with_reference_via_rsid.py
@@ -14,7 +14,7 @@ from mecfs_bio.build_system.task.fake_task import FakeTask
 from mecfs_bio.build_system.task.harmonize_gwas_with_reference_table_via_rsid import (
     HarmonizeGWASWithReferenceViaRSIDTask,
 )
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 from mecfs_bio.constants.gwaslab_constants import (
     GWASLAB_BETA_COL,
     GWASLAB_CHROM_COL,
@@ -153,7 +153,7 @@ def test_harmonize_gwas_with_reference(tmp_path: Path):
             return FileAsset(reference_path)
         raise ValueError(f"Unknown asset {asset_id}")
 
-    result = tsk.execute(scratch_dir=scratch_dir, fetch=fetch, wf=SimpleWF())
+    result = tsk.execute(scratch_dir=scratch_dir, fetch=fetch, wf=make_wf())
     assert isinstance(result, FileAsset)
     result_df = pd.read_parquet(result.path)
     assert set(result_df[GWASLAB_RSID_COL].tolist()) == {"rs100", "rs300"}

--- a/test_mecfs_bio/unit/build_system/task/test_join_dataframes_task.py
+++ b/test_mecfs_bio/unit/build_system/task/test_join_dataframes_task.py
@@ -12,7 +12,7 @@ from mecfs_bio.build_system.meta.read_spec.dataframe_read_spec import (
 from mecfs_bio.build_system.meta.simple_file_meta import SimpleFileMeta
 from mecfs_bio.build_system.task.fake_task import FakeTask
 from mecfs_bio.build_system.task.join_dataframes_task import JoinDataFramesTask
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 
 
 def test_join_dataframes_task(tmp_path: Path):
@@ -50,7 +50,7 @@ def test_join_dataframes_task(tmp_path: Path):
             return FileAsset(df_2_loc)
         raise ValueError("unknown asset id")
 
-    result = task.execute(scratch_dir=scratch_loc, fetch=fetch, wf=SimpleWF())
+    result = task.execute(scratch_dir=scratch_loc, fetch=fetch, wf=make_wf())
     assert isinstance(result, FileAsset)
     result_df = pd.read_csv(result.path)
     assert len(result_df) == 3

--- a/test_mecfs_bio/unit/build_system/task/test_magma_plot_gene_set_result.py
+++ b/test_mecfs_bio/unit/build_system/task/test_magma_plot_gene_set_result.py
@@ -7,7 +7,7 @@ from mecfs_bio.build_system.task.fake_task import FakeTask
 from mecfs_bio.build_system.task.magma.magma_plot_gene_set_result import (
     MAGMAPlotGeneSetResult,
 )
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 
 
 def test_plot_gene_set_result(tmp_path: Path):
@@ -23,5 +23,5 @@ def test_plot_gene_set_result(tmp_path: Path):
             Path("test_mecfs_bio/unit/dummy_data/fake_gene_set_result")
         )
 
-    result = plot_task.execute(scratch_dir=scratch, fetch=fetch, wf=SimpleWF())
+    result = plot_task.execute(scratch_dir=scratch, fetch=fetch, wf=make_wf())
     assert isinstance(result, DirectoryAsset)

--- a/test_mecfs_bio/unit/build_system/task/test_magma_snp_locations_task.py
+++ b/test_mecfs_bio/unit/build_system/task/test_magma_snp_locations_task.py
@@ -18,13 +18,13 @@ from mecfs_bio.build_system.rebuilder.verifying_trace_rebuilder.verifying_trace_
 from mecfs_bio.build_system.scheduler.topological_scheduler import topological
 from mecfs_bio.build_system.task.base_task import Task
 from mecfs_bio.build_system.tasks.simple_tasks import find_tasks
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 
 
 def test_magma_snp_locations_task(tmp_path: Path, magma_snp_locations_task: Task):
     tasks = find_tasks([magma_snp_locations_task])
 
-    wf = SimpleWF()
+    wf = make_wf()
     info: VerifyingTraceInfo = VerifyingTraceInfo.empty()
 
     asset_dir = tmp_path / "asset_dir"

--- a/test_mecfs_bio/unit/build_system/task/test_specificity_cepo.py
+++ b/test_mecfs_bio/unit/build_system/task/test_specificity_cepo.py
@@ -16,7 +16,7 @@ from mecfs_bio.build_system.task.specificity_cepo_task import (
     DIFFERENTIAL_STABILITY,
     PrepareSpecificityCepo,
 )
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 from mecfs_bio.util.type_related.unwrap import unwrap
 
 _dummy_df = pd.DataFrame(  # X is stable in A.  Y is stable in B
@@ -69,7 +69,7 @@ def test_prepare_specificity_cepo(tmp_path: Path):
             return FileAsset(df_loc)
         raise ValueError("unknown asset id")
 
-    result = tsk.execute(scratch_dir=scratch_loc, fetch=fetch, wf=SimpleWF())
+    result = tsk.execute(scratch_dir=scratch_loc, fetch=fetch, wf=make_wf())
     assert isinstance(result, FileAsset)
     result_df = pd.read_parquet(result.path)
 

--- a/test_mecfs_bio/unit/build_system/task/test_specificity_frac.py
+++ b/test_mecfs_bio/unit/build_system/task/test_specificity_frac.py
@@ -16,7 +16,7 @@ from mecfs_bio.build_system.task.specificity_frac_task import (
     NORMALIZED_MEAN,
     PrepareSpecificityFraction,
 )
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 from mecfs_bio.util.type_related.unwrap import unwrap
 
 _dummy_df = pd.DataFrame(  # According to the fractional metric, Y is specific for A, while X is specifific for V
@@ -55,7 +55,7 @@ def test_prepare_specificity_frac(tmp_path: Path):
             return FileAsset(df_loc)
         raise ValueError("unknown asset id")
 
-    result = tsk.execute(scratch_dir=scratch_loc, fetch=fetch, wf=SimpleWF())
+    result = tsk.execute(scratch_dir=scratch_loc, fetch=fetch, wf=make_wf())
     assert isinstance(result, FileAsset)
     result_df = pd.read_parquet(result.path)
 

--- a/test_mecfs_bio/unit/build_system/task/test_sqlite_to_parquet_task.py
+++ b/test_mecfs_bio/unit/build_system/task/test_sqlite_to_parquet_task.py
@@ -17,7 +17,7 @@ from mecfs_bio.build_system.meta.reference_meta.reference_file_meta import (
 from mecfs_bio.build_system.rebuilder.fetch.base_fetch import Fetch
 from mecfs_bio.build_system.task.fake_task import FakeTask
 from mecfs_bio.build_system.task.sqlite_to_parquet_task import SqliteToParquetTask
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 
 
 def _make_sqlite_db(tmp_path: Path) -> Path:
@@ -73,7 +73,7 @@ def test_sqlite_to_parquet_simple_query(tmp_path: Path):
         asset_id="out",
         query="SELECT id, name, collection FROM _src.gene_set",
     )
-    result = task.execute(scratch_dir=scratch, fetch=_FileFetch(db_path), wf=SimpleWF())
+    result = task.execute(scratch_dir=scratch, fetch=_FileFetch(db_path), wf=make_wf())
 
     assert isinstance(result, FileAsset)
     df = pd.read_parquet(result.path)
@@ -103,7 +103,7 @@ def test_sqlite_to_parquet_with_list_aggregation(tmp_path: Path):
             GROUP BY gs.id, gs.name\
         """,
     )
-    result = task.execute(scratch_dir=scratch, fetch=_FileFetch(db_path), wf=SimpleWF())
+    result = task.execute(scratch_dir=scratch, fetch=_FileFetch(db_path), wf=make_wf())
     assert isinstance(result, FileAsset)
 
     df = pd.read_parquet(result.path)

--- a/test_mecfs_bio/unit/build_system/task/test_susie_r_finemap_task.py
+++ b/test_mecfs_bio/unit/build_system/task/test_susie_r_finemap_task.py
@@ -63,7 +63,7 @@ from mecfs_bio.build_system.task.susie_stacked_plot_task import (
     SusieStackPlotTask,
 )
 from mecfs_bio.build_system.tasks.simple_tasks import find_tasks
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 from mecfs_bio.constants.gwaslab_constants import (
     GWASLAB_BETA_COL,
     GWASLAB_CHROM_COL,
@@ -276,7 +276,7 @@ def test_fine_mapping(
         heatmap_options=HeatmapOptions(BinOptions(num_bins=50), mode="ld2"),
     )
     tasks = find_tasks([susie_tsk, stack_plot_task])
-    wf = SimpleWF()
+    wf = make_wf()
     info: VerifyingTraceInfo = VerifyingTraceInfo.empty()
 
     asset_dir = tmp_path / "asset_dir"

--- a/test_mecfs_bio/unit/build_system/task/test_two_sample_mr_task.py
+++ b/test_mecfs_bio/unit/build_system/task/test_two_sample_mr_task.py
@@ -27,7 +27,7 @@ from mecfs_bio.build_system.task.two_sample_mr_task import (
     TwoSampleMRTask,
     run_two_sample_mr,
 )
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 
 dummy_exposure = pd.DataFrame(
     {
@@ -139,7 +139,7 @@ def test_two_sample_mr_task(tmp_path: Path):
             return FileAsset(dummy_exposure_path)
         raise ValueError("unknown asset id")
 
-    result = task.execute(scratch_dir=scratch_loc, fetch=fetch, wf=SimpleWF())
+    result = task.execute(scratch_dir=scratch_loc, fetch=fetch, wf=make_wf())
     assert isinstance(result, DirectoryAsset)
     loaded_result = pd.read_csv((result.path) / MAIN_RESULT_DF_PATH)
     assert loaded_result[TSM_OUTPUT_B_COL].item() == pytest.approx(2, abs=0.1)

--- a/test_mecfs_bio/unit/build_system/task/test_upset_plot_task.py
+++ b/test_mecfs_bio/unit/build_system/task/test_upset_plot_task.py
@@ -18,7 +18,7 @@ from mecfs_bio.build_system.task.upset_plot_task import (
     FileSetSource,
     UpSetPlotTask,
 )
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 
 
 @pytest.mark.parametrize(
@@ -73,5 +73,5 @@ def test_upset_plot_task(
             return DirectoryAsset(dir1_path)
         raise ValueError(f"Unknown asset id {asset_id}")
 
-    result = plot_task.execute(scratch_dir=scratch, fetch=fetch, wf=SimpleWF())
+    result = plot_task.execute(scratch_dir=scratch, fetch=fetch, wf=make_wf())
     assert isinstance(result, FileAsset)

--- a/test_mecfs_bio/unit/build_system/task/test_whitespace_sep_text_to_parquet_task.py
+++ b/test_mecfs_bio/unit/build_system/task/test_whitespace_sep_text_to_parquet_task.py
@@ -17,7 +17,7 @@ from mecfs_bio.build_system.task.fake_task import FakeTask
 from mecfs_bio.build_system.task.whitespace_sep_text_to_parquet_task import (
     WhitespaceSepTextToParquetTask,
 )
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 
 # Variable-width spacing (like the deCODE alignment padding) plus a column that is "NA"
 # in early rows and numeric later, to exercise streaming parse and cross-chunk schema.
@@ -59,7 +59,7 @@ def test_whitespace_sep_text_to_parquet_streams_and_preserves_values(tmp_path: P
         def __call__(self, asset_id: AssetId) -> Asset:
             return FileAsset(src)
 
-    result = task.execute(scratch_dir=scratch, fetch=_Fetch(), wf=SimpleWF())
+    result = task.execute(scratch_dir=scratch, fetch=_Fetch(), wf=make_wf())
     assert isinstance(result, FileAsset)
 
     df = pl.read_parquet(result.path)
@@ -117,7 +117,7 @@ def test_lossy_cross_chunk_type_change_raises(tmp_path: Path):
         source_task=source_task, asset_id="raw_parquet", chunk_size=2
     )
     with pytest.raises(ValueError, match="dtype="):
-        task.execute(scratch_dir=scratch, fetch=fetch, wf=SimpleWF())
+        task.execute(scratch_dir=scratch, fetch=fetch, wf=make_wf())
 
 
 def test_dtype_override_pins_mixed_chromosome_column(tmp_path: Path):
@@ -134,7 +134,7 @@ def test_dtype_override_pins_mixed_chromosome_column(tmp_path: Path):
         chunk_size=2,
         dtype={"Chr": "str"},
     )
-    result = task.execute(scratch_dir=scratch, fetch=fetch, wf=SimpleWF())
+    result = task.execute(scratch_dir=scratch, fetch=fetch, wf=make_wf())
     assert isinstance(result, FileAsset)
     df = pl.read_parquet(result.path)
     assert df["Chr"].to_list() == ["1", "2", "X", "Y"]

--- a/test_mecfs_bio/unit/build_system/task/test_zip_dir_task.py
+++ b/test_mecfs_bio/unit/build_system/task/test_zip_dir_task.py
@@ -9,7 +9,7 @@ from mecfs_bio.build_system.meta.simple_directory_meta import SimpleDirectoryMet
 from mecfs_bio.build_system.meta.simple_file_meta import SimpleFileMeta
 from mecfs_bio.build_system.task.fake_task import FakeTask
 from mecfs_bio.build_system.task.zip_dir_task import ZipDirTask
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 
 
 def test_zip_dir_task(tmp_path: Path):
@@ -29,7 +29,7 @@ def test_zip_dir_task(tmp_path: Path):
     def fetch(asset_id: AssetId) -> Asset:
         return DirectoryAsset(to_zip)
 
-    result = tsk.execute(scratch_dir=scratch_dir, fetch=fetch, wf=SimpleWF())
+    result = tsk.execute(scratch_dir=scratch_dir, fetch=fetch, wf=make_wf())
     assert isinstance(result, FileAsset)
     shutil.unpack_archive(result.path, unpacked_result)
     assert (unpacked_result / "file_1.txt").read_text() == "hello"

--- a/test_mecfs_bio/unit/build_system/wf/test_synapse_downloader.py
+++ b/test_mecfs_bio/unit/build_system/wf/test_synapse_downloader.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from mecfs_bio.build_system.wf.base_wf import SimpleWF
+from mecfs_bio.build_system.wf.base_wf import make_wf
 from mecfs_bio.build_system.wf.synapse_downloader import SynapseDownloader
 
 
@@ -17,7 +17,7 @@ class _RecordingDownloader(SynapseDownloader):
 
 def test_wf_delegates_download_from_synapse(tmp_path: Path):
     fake = _RecordingDownloader()
-    wf = SimpleWF(synapse_downloader=fake)
+    wf = make_wf(synapse_downloader=fake)
 
     out = wf.download_from_synapse("syn123", tmp_path, "protein.tar")
 


### PR DESCRIPTION
- `WF` is intended to represent an interface to the external world.  Currently, it makes use of inheritance.  However, composition is a better choice than inheritance for WF's purpose, since it prevents a combinatorial explosion of subclasses as capabilities are added.
- This PR refactors `WF` to use composition.  