### PR TITLE
Configure Renovate bot

### DIFF
--- a/.github/workflows/lockfile_maintenance_gate.yml
+++ b/.github/workflows/lockfile_maintenance_gate.yml
@@ -1,10 +1,4 @@
 name: lockfile_maintenance_gate
-# Runs the standard decodeme system test ONLY on Renovate's lockFileMaintenance
-# PRs (branch `renovate/lock-file-maintenance`). On every other PR the job is
-# skipped, so normal PRs are unaffected. With `platformAutomerge: false` on the
-# lockFileMaintenance rule, Renovate-managed automerge blocks on all check runs
-# present on the branch head -- including this one -- so a failure here prevents
-# the lock refresh from automerging. See renovate.json.
 on:
   pull_request:
     branches:

--- a/.github/workflows/lockfile_maintenance_gate.yml
+++ b/.github/workflows/lockfile_maintenance_gate.yml
@@ -1,0 +1,25 @@
+name: lockfile_maintenance_gate
+# Runs the standard decodeme system test ONLY on Renovate's lockFileMaintenance
+# PRs (branch `renovate/lock-file-maintenance`). On every other PR the job is
+# skipped, so normal PRs are unaffected. With `platformAutomerge: false` on the
+# lockFileMaintenance rule, Renovate-managed automerge blocks on all check runs
+# present on the branch head -- including this one -- so a failure here prevents
+# the lock refresh from automerging. See renovate.json.
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lead_variants:
+    if: github.head_ref == 'renovate/lock-file-maintenance'
+    timeout-minutes: 600
+    name: Compute Lead Variants
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v7
+      - name: Run lead variants integration test
+        uses: ./.github/actions/run-system-test
+        with:
+          pytest-target: test_mecfs_bio/system/test_decode_me_initial_analysis.py

--- a/pixi.lock
+++ b/pixi.lock
@@ -589,7 +589,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/e2/9baffdae21a76f77ef8447f1a05a96ec4bc0a24dae08767abc0a2fe680b8/multidict-6.7.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bf/b6/5f922792be93b82ec6b5f270bbb1ef031fd0622847070bbcf9da816502cc/multiprocess-0.70.18-py312-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a6/01/67cf210d50bfefbb9224b9a5c465857c1767388dade1004c903c8e22a991/mysql_connector_python-9.5.0-cp312-cp312-manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/29/13/024ae0586d901f8a6f99e2d29b4ae217e8ef11d3fd944cdfc3bbde5f2a08/narwhals-2.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7e/85/a5bfaebfd305ac18b57b0854d74e37e586809061a91fda62f0bd50c8518e/narwhals-2.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/ae/defd665dbbeb2fffa077491365ed160acaec49274ce8d4b979f55db71f18/ndindex-1.10.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
@@ -630,8 +630,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/73/cb/ac7874b3e5d58441674fb70742e6c374b28b0c7cb988d37d991cde47166c/platformdirs-4.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/67/f95b5460f127840310d2187f916cf0023b5875c0717fdf893f71e1325e87/plotly-6.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c3/c8/5807714256c5f3de08593113df17f14f99417a451cb2d91530ad94785003/polars-1.41.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/53/18/5a04b06b773047cbf43912ab802eef3c1d50ef7e66d51a41b16726f9bc62/polars_runtime_32-1.41.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/be/6a/edd939cc6fa04b6415aaa9bf19720fc74ead81234b3d38542e0005816d4d/polars-1.42.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/10/ffb85fa380bc9c9000dc35f40f44954dde49023018501c54faab94b3a39e/polars_runtime_32-1.42.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ee/94/448f037fb0ffd0e8a63b625cf9f5b13494b88d15573a987be8aaa735579d/progressbar2-4.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/46/4b/3aae6835b8e5f44ea6a68348ad90f78134047b503765087be2f9912140ea/propcache-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/4d/fc923f5c85318ee8cc903566dc4e0ebe41b2dfc1d2ecf5546db232397ed6/properdocs-1.6.7-py3-none-any.whl
@@ -6005,26 +6005,27 @@ packages:
   - opentelemetry-sdk==1.33.1 ; extra == 'telemetry'
   - opentelemetry-exporter-otlp-proto-http==1.33.1 ; extra == 'telemetry'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/29/13/024ae0586d901f8a6f99e2d29b4ae217e8ef11d3fd944cdfc3bbde5f2a08/narwhals-2.10.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/7e/85/a5bfaebfd305ac18b57b0854d74e37e586809061a91fda62f0bd50c8518e/narwhals-2.24.0-py3-none-any.whl
   name: narwhals
-  version: 2.10.0
-  sha256: baed44e8fc38e800e3a585e3fa9843a7079a6fad5fbffbecee4348d6ac52298c
+  version: 2.24.0
+  sha256: 42fdedf44e5b2ca7505630d45b4ac3058f38d8485cba9fe1652ca23152df7489
   requires_dist:
-  - cudf>=24.10.0 ; extra == 'cudf'
+  - cudf-cu12>=24.10.0 ; sys_platform == 'linux' and extra == 'cudf'
   - dask[dataframe]>=2024.8 ; extra == 'dask'
   - duckdb>=1.1 ; extra == 'duckdb'
   - ibis-framework>=6.0.0 ; extra == 'ibis'
-  - packaging ; extra == 'ibis'
-  - pyarrow-hotfix ; extra == 'ibis'
-  - rich ; extra == 'ibis'
-  - modin ; extra == 'modin'
-  - pandas>=1.1.3 ; extra == 'pandas'
+  - packaging>=21.3 ; extra == 'ibis'
+  - pyarrow-hotfix>=0.7 ; extra == 'ibis'
+  - modin>=0.22.0 ; extra == 'modin'
+  - pandas>=1.3.4 ; extra == 'pandas'
   - polars>=0.20.4 ; extra == 'polars'
   - pyarrow>=13.0.0 ; extra == 'pyarrow'
   - pyspark>=3.5.0 ; extra == 'pyspark'
   - pyspark[connect]>=3.5.0 ; extra == 'pyspark-connect'
+  - narwhals[duckdb] ; extra == 'sql'
+  - sqlparse>=0.5.5 ; extra == 'sql'
   - sqlframe>=3.22.0,!=3.39.3 ; extra == 'sqlframe'
-  requires_python: '>=3.9'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl
   name: natsort
   version: 8.4.0
@@ -6805,14 +6806,14 @@ packages:
   - pytest-benchmark ; extra == 'testing'
   - coverage ; extra == 'testing'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/c3/c8/5807714256c5f3de08593113df17f14f99417a451cb2d91530ad94785003/polars-1.41.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/be/6a/edd939cc6fa04b6415aaa9bf19720fc74ead81234b3d38542e0005816d4d/polars-1.42.1-py3-none-any.whl
   name: polars
-  version: 1.41.0
-  sha256: 35dcd24de88a198dc50929924f064ba12a0a0a4a3e77e116689491b4b3ab58ac
+  version: 1.42.1
+  sha256: 3c0c65cdfa21a621650c4bdcbbccf93964d052fd766c3e70e84a55d961c259fd
   requires_dist:
-  - polars-runtime-32==1.41.0
-  - polars-runtime-64==1.41.0 ; extra == 'rt64'
-  - polars-runtime-compat==1.41.0 ; extra == 'rtcompat'
+  - polars-runtime-32==1.42.1
+  - polars-runtime-64==1.42.1 ; extra == 'rt64'
+  - polars-runtime-compat==1.42.1 ; extra == 'rtcompat'
   - polars-cloud>=0.4.0 ; extra == 'polars-cloud'
   - numpy>=1.16.0 ; extra == 'numpy'
   - pandas ; extra == 'pandas'
@@ -6842,10 +6843,10 @@ packages:
   - cudf-polars-cu12 ; extra == 'gpu'
   - polars[async,cloudpickle,database,deltalake,excel,fsspec,graph,iceberg,numpy,pandas,plot,pyarrow,pydantic,style,timezone] ; extra == 'all'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/53/18/5a04b06b773047cbf43912ab802eef3c1d50ef7e66d51a41b16726f9bc62/polars_runtime_32-1.41.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/5d/10/ffb85fa380bc9c9000dc35f40f44954dde49023018501c54faab94b3a39e/polars_runtime_32-1.42.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: polars-runtime-32
-  version: 1.41.0
-  sha256: e72269f768c57229190dba0cb5abb8a1b228e96cc6331273a77a7957576885bd
+  version: 1.42.1
+  sha256: d059e8e53cc114ff82f9bd791fd341dc53534a2c745e6f6aa37594c3a93f01fe
   requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/poppler-26.07.0-he594abd_3.conda
   sha256: 646869d659de20b98caf6e249b468d1a13b4593f5d83ce7f269fc75aed18faf0

--- a/renovate.json
+++ b/renovate.json
@@ -47,7 +47,6 @@
       "matchPackageNames": [
         "narwhals",
         "polars",
-        "loguru",
         "structlog",
         "tqdm",
         "invoke",

--- a/renovate.json
+++ b/renovate.json
@@ -40,6 +40,25 @@
       ],
       "matchUpdateTypes": ["major","minor", "patch"],
       "automerge": true
+    },
+    {
+      "description": "Leaf deps with no dependents: pin exactly so every release gets its own PR. Do NOT add tightly-coupled scientific-stack packages (numpy, pandas, matplotlib, scipy, xarray) here -- gwaslab constrains them, and per-package pin PRs would be individually unsatisfiable.",
+      "matchManagers": ["pixi"],
+      "matchPackageNames": [
+        "narwhals",
+        "polars",
+        "loguru",
+        "structlog",
+        "tqdm",
+        "invoke",
+        "ruff",
+        "typeguard"
+      ],
+      "rangeStrategy": "pin"
     }
-  ]
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 4am on monday"]
+  }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -58,6 +58,8 @@
   ],
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["before 4am on monday"]
+    "schedule": ["before 4am on saturday"],
+    "automerge": true,
+    "platformAutomerge": false
   }
 }


### PR DESCRIPTION
- Problem: I noticed that renovate was not generating PRs to update polars or narwhals.
- Issue: in its default settings, renovate only generates PRs when a version is released that falls outside of the range specified in pyproject.toml
- Partial solution: use the renovate "pin" setting for polars, narwhals, and a few other leaf packages.  This means whenever a new version is released, renovate will create a PR pinning this new version.
- Problem: if we take this approach for all libraries, we will get a very hard to satisfy set of version dependencies. 
- Solution: only use pin for a few lead packages.  For the rest, use lockfile maintience. 
- Also add a workflow that triggers a system test on lockfile maintinance, to catch any major issues early