### PR TITLE
Ppp rg collapse multi assay pipe

### DIFF
--- a/mecfs_bio/asset_generator/ukbb_ppp_rg_asset_generator.py
+++ b/mecfs_bio/asset_generator/ukbb_ppp_rg_asset_generator.py
@@ -1,5 +1,6 @@
 from collections import Counter
 
+import narwhals
 from attrs import frozen
 
 from mecfs_bio.assets.gwas.ukbb_ppp.ppp_database.hapmap3.eur_discovery_hapmap3_ppp_database_protein_files import (
@@ -37,17 +38,21 @@ from mecfs_bio.build_system.task.pipes.filter_rows_by_min_in_col import (
     FilterRowsByMinInCol,
 )
 from mecfs_bio.build_system.task.pipes.identity_pipe import IdentityPipe
+from mecfs_bio.build_system.task.pipes.multiple_testing_pipe import MultipleTestingPipe
+from mecfs_bio.build_system.task.pipes.rename_col_pipe import RenameColPipe
+from mecfs_bio.build_system.task.pipes.replace_pipe import ReplaceStrictPipe
 from mecfs_bio.build_system.task.ppp_ldsc.ppp_protein_rg_task import (
     PppProteinCrossTraitRgTask,
     PppRgConfig,
 )
 from mecfs_bio.constants.ppp_ldsc_constants import (
+    PPP_RG_GCOV_INTERCEPT_COL,
     PPP_RG_H2_PROTEIN_COL,
-    PPP_RG_N_BAR_PROTEIN_COL,
-    PPP_RG_N_BAR_TRAIT_COL,
+    PPP_RG_N_ASSAYS_COL,
     PPP_RG_RG_COL,
+    PPP_RG_RG_P_COL,
     PPP_RG_RG_SE_COL,
-    PPP_RG_RG_Z_COL,
+    PPP_RG_VARIANT_SET_COL,
     PPP_VARIANT_SET_CIS_EXCLUDED,
 )
 
@@ -86,7 +91,7 @@ def generate_ppp_rg_assets(
     trait_task: Task,
     config: PppRgConfig = PppRgConfig(),
     trait_pipe: DataProcessingPipe = IdentityPipe(),
-):
+) -> PppRgTasks:
     rg_task = PppProteinCrossTraitRgTask.create(
         asset_id=base_name + "_rg_task",
         trait_task=trait_task,
@@ -107,18 +112,38 @@ def generate_ppp_rg_assets(
     display_frame_task = PipeDataFrameTask.create(
         source_task=rg_task,
         pipes=[
-            DropColPipe(
-                [PPP_RG_RG_Z_COL, PPP_RG_N_BAR_PROTEIN_COL, PPP_RG_N_BAR_TRAIT_COL]
-            ),
-            DropNanPipe(cols=[PPP_RG_RG_COL, PPP_RG_RG_SE_COL]),
             # Combine assay rows of the same protein (measured on multiple Olink panels) into one
             # row before ranking/filtering
             CollapseMultiAssayProteinsPipe(
                 duplicate_oid_to_group=_duplicate_oid_to_uniprot()
             ),
+            ReplaceStrictPipe(
+                target_column=PPP_RG_RG_P_COL,
+                new_column_name=PPP_RG_RG_P_COL,
+                replace_mapping={float("nan"): 1},
+                default=narwhals.col(PPP_RG_RG_P_COL),
+            ),  # nan values contaminate the multiple testing correction
+            MultipleTestingPipe(
+                p_col=PPP_RG_RG_P_COL, reject_name="s_bh", method="fdr_bh"
+            ),
+            MultipleTestingPipe(
+                p_col=PPP_RG_RG_P_COL, reject_name="s_bon", method="bonferroni"
+            ),
+            DropNanPipe(cols=[PPP_RG_RG_COL, PPP_RG_RG_SE_COL]),
             FilterRowsByMinInCol(min_value=0.02, col=PPP_RG_H2_PROTEIN_COL),
+            DropColPipe(
+                [
+                    # PPP_RG_RG_Z_COL, PPP_RG_N_BAR_PROTEIN_COL, PPP_RG_N_BAR_TRAIT_COL,
+                    PPP_RG_VARIANT_SET_COL,
+                    PPP_RG_N_ASSAYS_COL,  # PPP_RG_N_SNPS_COL
+                ]
+            ),
             CastFloatsToFloat32Pipe(),
             CastIntsToInt32Pipe(),
+            RenameColPipe(
+                PPP_RG_GCOV_INTERCEPT_COL, "inter"
+            ),  # shorten column names so table fits on screen in docs
+            RenameColPipe(PPP_RG_H2_PROTEIN_COL, "h2_prot"),
         ],
         asset_id=base_name + "_display_frame",
         out_format=ParquetOutFormat(

--- a/mecfs_bio/asset_generator/ukbb_ppp_rg_asset_generator.py
+++ b/mecfs_bio/asset_generator/ukbb_ppp_rg_asset_generator.py
@@ -1,3 +1,5 @@
+from collections import Counter
+
 from attrs import frozen
 
 from mecfs_bio.assets.gwas.ukbb_ppp.ppp_database.hapmap3.eur_discovery_hapmap3_ppp_database_protein_files import (
@@ -16,18 +18,67 @@ from mecfs_bio.assets.reference_data.pqtls.processed.sun_et_al_2023_st3_extracte
     SUN_ET_AL_2023_ST3_EXTRACTED,
 )
 from mecfs_bio.build_system.task.base_task import Task
+from mecfs_bio.build_system.task.dataframe_output import (
+    ParquetOutFormat,
+    ParquetWriteOptions,
+)
+from mecfs_bio.build_system.task.pipe_dataframe_task import PipeDataFrameTask
+from mecfs_bio.build_system.task.pipes.cast_to_float32_pipe import (
+    CastFloatsToFloat32Pipe,
+)
+from mecfs_bio.build_system.task.pipes.cast_to_int32pipe import CastIntsToInt32Pipe
+from mecfs_bio.build_system.task.pipes.collapse_multi_assay_proteins_pipe import (
+    CollapseMultiAssayProteinsPipe,
+)
 from mecfs_bio.build_system.task.pipes.data_processing_pipe import DataProcessingPipe
+from mecfs_bio.build_system.task.pipes.drop_col_pipe import DropColPipe
+from mecfs_bio.build_system.task.pipes.drop_nan_pipe import DropNanPipe
+from mecfs_bio.build_system.task.pipes.filter_rows_by_min_in_col import (
+    FilterRowsByMinInCol,
+)
 from mecfs_bio.build_system.task.pipes.identity_pipe import IdentityPipe
 from mecfs_bio.build_system.task.ppp_ldsc.ppp_protein_rg_task import (
     PppProteinCrossTraitRgTask,
     PppRgConfig,
 )
-from mecfs_bio.constants.ppp_ldsc_constants import PPP_VARIANT_SET_CIS_EXCLUDED
+from mecfs_bio.constants.ppp_ldsc_constants import (
+    PPP_RG_H2_PROTEIN_COL,
+    PPP_RG_N_BAR_PROTEIN_COL,
+    PPP_RG_N_BAR_TRAIT_COL,
+    PPP_RG_RG_COL,
+    PPP_RG_RG_SE_COL,
+    PPP_RG_RG_Z_COL,
+    PPP_VARIANT_SET_CIS_EXCLUDED,
+)
 
 
 @frozen
 class PppRgTasks:
     rg_task: Task
+    display_frame_task: Task
+
+    def get_terminal_tasks(self) -> list[Task]:
+        return [self.rg_task, self.display_frame_task]
+
+
+def _duplicate_oid_to_uniprot() -> tuple[tuple[str, str], ...]:
+    """OID -> UniProt for every protein assay whose UniProt is shared by more than one assay.
+
+    These are the multi-panel proteins (TNF, IL6, CXCL8, ...) that the collapse pipe combines;
+    every other OID is left out and forms its own singleton group. Sorted for a stable task
+    identity."""
+    oid_uniprot = [
+        (task.protein.oid, task.protein.uniprot)
+        for task in HAPMAP_3_PPP_DATABASE.protein_tasks
+    ]
+    uniprot_counts = Counter(uniprot for _, uniprot in oid_uniprot)
+    return tuple(
+        sorted(
+            (oid, uniprot)
+            for oid, uniprot in oid_uniprot
+            if uniprot_counts[uniprot] > 1
+        )
+    )
 
 
 def generate_ppp_rg_assets(
@@ -36,21 +87,48 @@ def generate_ppp_rg_assets(
     config: PppRgConfig = PppRgConfig(),
     trait_pipe: DataProcessingPipe = IdentityPipe(),
 ):
-    return PppRgTasks(
-        rg_task=PppProteinCrossTraitRgTask.create(
-            asset_id=base_name + "_rg_task",
-            trait_task=trait_task,
-            protein_tasks=HAPMAP_3_PPP_DATABASE.protein_tasks,
-            index_task=HAPMAP_3_PPP_DATABASE_INDEX,
-            ld_scores_task=THOUSAND_GENOME_EUR_LD_REFERENCE_DATA_V1_CONSOLIDATE,
-            sample_size_task=PPP_SAMPLE_SIZES,
-            # Gene coordinates are only consulted to build cis windows.
-            gene_coords_task=(
-                SUN_ET_AL_2023_ST3_EXTRACTED
-                if config.variant_set == PPP_VARIANT_SET_CIS_EXCLUDED
-                else None
-            ),
-            config=config,
-            trait_pipe=trait_pipe,
+    rg_task = PppProteinCrossTraitRgTask.create(
+        asset_id=base_name + "_rg_task",
+        trait_task=trait_task,
+        protein_tasks=HAPMAP_3_PPP_DATABASE.protein_tasks,
+        index_task=HAPMAP_3_PPP_DATABASE_INDEX,
+        ld_scores_task=THOUSAND_GENOME_EUR_LD_REFERENCE_DATA_V1_CONSOLIDATE,
+        sample_size_task=PPP_SAMPLE_SIZES,
+        # Gene coordinates are only consulted to build cis windows.
+        gene_coords_task=(
+            SUN_ET_AL_2023_ST3_EXTRACTED
+            if config.variant_set == PPP_VARIANT_SET_CIS_EXCLUDED
+            else None
         ),
+        config=config,
+        trait_pipe=trait_pipe,
+    )
+
+    display_frame_task = PipeDataFrameTask.create(
+        source_task=rg_task,
+        pipes=[
+            DropColPipe(
+                [PPP_RG_RG_Z_COL, PPP_RG_N_BAR_PROTEIN_COL, PPP_RG_N_BAR_TRAIT_COL]
+            ),
+            DropNanPipe(cols=[PPP_RG_RG_COL, PPP_RG_RG_SE_COL]),
+            # Combine assay rows of the same protein (measured on multiple Olink panels) into one
+            # row before ranking/filtering
+            CollapseMultiAssayProteinsPipe(
+                duplicate_oid_to_group=_duplicate_oid_to_uniprot()
+            ),
+            FilterRowsByMinInCol(min_value=0.02, col=PPP_RG_H2_PROTEIN_COL),
+            CastFloatsToFloat32Pipe(),
+            CastIntsToInt32Pipe(),
+        ],
+        asset_id=base_name + "_display_frame",
+        out_format=ParquetOutFormat(
+            ParquetWriteOptions(
+                compression="zstd", compression_level=22, byte_stream_split_floats=True
+            )
+        ),
+    )
+
+    return PppRgTasks(
+        rg_task=rg_task,
+        display_frame_task=display_frame_task,
     )

--- a/mecfs_bio/assets/gwas/ukbb_ppp/ppp_database/hapmap3/eur_discovery_hapmap_3_heritability_figure_table.py
+++ b/mecfs_bio/assets/gwas/ukbb_ppp/ppp_database/hapmap3/eur_discovery_hapmap_3_heritability_figure_table.py
@@ -24,7 +24,9 @@ from mecfs_bio.build_system.task.pipes.attenuation_ratio_pipe import (
     AttenuationRatioPipe,
 )
 from mecfs_bio.build_system.task.pipes.cast_pipe import CastPipe
-from mecfs_bio.build_system.task.pipes.cast_to_float32_pipe import CastToFloat32Pipe
+from mecfs_bio.build_system.task.pipes.cast_to_float32_pipe import (
+    CastFloatsToFloat32Pipe,
+)
 from mecfs_bio.build_system.task.pipes.compute_p_from_beta_se import (
     ComputePFromBetaSEPipeIfNeeded,
 )
@@ -56,7 +58,7 @@ HAPMAP_3_PPP_HERITABILITY_FIGURE_TABLE = PipeDataFrameTask.create(
             mean_chi_col=PPP_H2_MEAN_CHI2_COL, intercept_col=PPP_H2_INTERCEPT_COL
         ),
         DropColPipe([PPP_H2_LAMBDA_GC_COL]),
-        CastToFloat32Pipe(),  # the input data for PPP LDSC is float32, so it is reasonable to cast the output to float32 as well
+        CastFloatsToFloat32Pipe(),  # the input data for PPP LDSC is float32, so it is reasonable to cast the output to float32 as well
     ],
     out_format=ParquetOutFormat(
         write_options=ParquetWriteOptions(

--- a/mecfs_bio/build_system/task/pipes/cast_to_int32pipe.py
+++ b/mecfs_bio/build_system/task/pipes/cast_to_int32pipe.py
@@ -5,12 +5,12 @@ from mecfs_bio.build_system.task.pipes.data_processing_pipe import DataProcessin
 
 
 @frozen
-class CastFloatsToFloat32Pipe(DataProcessingPipe):
+class CastIntsToInt32Pipe(DataProcessingPipe):
     """
-    Convert all float64 columns to float32
+    Convert all int64 to int32
     """
 
     def process(self, x: narwhals.LazyFrame) -> narwhals.LazyFrame:
         return x.with_columns(
-            narwhals.selectors.by_dtype(narwhals.Float64).cast(narwhals.Float32)
+            narwhals.selectors.by_dtype(narwhals.Int64).cast(narwhals.Int32)
         )

--- a/mecfs_bio/build_system/task/pipes/collapse_multi_assay_proteins_pipe.py
+++ b/mecfs_bio/build_system/task/pipes/collapse_multi_assay_proteins_pipe.py
@@ -129,12 +129,12 @@ class CollapseMultiAssayProteinsPipe(DataProcessingPipe):
             PPP_RG_RG_COL,
             PPP_RG_RG_SE_COL,
             PPP_RG_RG_P_COL,
-            PPP_RG_RG_SPREAD_COL,
-            PPP_RG_N_ASSAYS_COL,
             PPP_RG_GCOV_COL,
             PPP_RG_GCOV_INTERCEPT_COL,
             PPP_RG_H2_TRAIT_COL,
             PPP_RG_H2_PROTEIN_COL,
             PPP_RG_N_SNPS_COL,
+            PPP_RG_RG_SPREAD_COL,
+            PPP_RG_N_ASSAYS_COL,
         ).sort(PPP_RG_RG_P_COL)
         return narwhals.from_native(ordered).lazy()

--- a/mecfs_bio/build_system/task/pipes/collapse_multi_assay_proteins_pipe.py
+++ b/mecfs_bio/build_system/task/pipes/collapse_multi_assay_proteins_pipe.py
@@ -1,0 +1,140 @@
+"""
+Collapse the per-assay UKB-PPP rg table to one row per protein.
+
+A handful of proteins are measured on more than one Olink Explore panel (e.g. TNF, IL6, CXCL8,
+IDO1, LMOD1, SCRIB on all four v1 panels), so they appear as several assay rows -- same UniProt,
+different OID -- each with its own genetic-correlation estimate. Keeping all of them distorts a
+ranked / thresholded discussion list: a multi-panel protein gets several chances to cross a
+significance cut-off, and if it enters via its most significant panel the reported rg is
+winner's-curse inflated.
+
+This pipe combines a protein's assay rows into a single row. Because the assay estimates share the
+same trait GWAS (and largely the same protein signal), they are strongly positively correlated, so
+a naive fixed-effect meta-analysis would badly understate the combined SE. We therefore combine
+under the conservative worst-case assumption of perfect correlation between assays, for which
+standard deviations add linearly:
+
+    rg_comb = sum(rg_i / se_i^2) / sum(1 / se_i^2)      (inverse-variance weighted mean)
+    se_comb = sum(1 / se_i)     / sum(1 / se_i^2)       (same-weighted mean of the SEs)
+
+At perfect correlation Var(sum w_i rg_i) = (sum w_i se_i)^2, and Var is monotincreasing in the
+pairwise correlation, so se_comb is never smaller than the truth for any real correlation. The
+point estimate is a weighted mean (not the max), so one lucky panel cannot inflate it. z and p are
+recomputed from the combined estimate.
+
+Only duplicated OIDs need combining; every other OID forms a singleton group and passes through
+unchanged (the formulas above are a no-op on a single row). The pipe carries the small
+OID -> shared-key map for the duplicated OIDs only.
+"""
+
+from __future__ import annotations
+
+import narwhals
+import numpy as np
+import polars as pl
+import scipy.stats
+from attrs import frozen
+
+from mecfs_bio.build_system.task.pipes.data_processing_pipe import DataProcessingPipe
+from mecfs_bio.constants.ppp_ldsc_constants import (
+    PPP_RG_GCOV_COL,
+    PPP_RG_GCOV_INTERCEPT_COL,
+    PPP_RG_GENE_COL,
+    PPP_RG_H2_PROTEIN_COL,
+    PPP_RG_H2_TRAIT_COL,
+    PPP_RG_N_ASSAYS_COL,
+    PPP_RG_N_SNPS_COL,
+    PPP_RG_OID_COL,
+    PPP_RG_RG_COL,
+    PPP_RG_RG_P_COL,
+    PPP_RG_RG_SE_COL,
+    PPP_RG_RG_SPREAD_COL,
+    PPP_RG_VARIANT_SET_COL,
+)
+
+# Temporary group key and partial-sum columns (dropped before returning).
+_GROUP = "__protein_group__"
+_SUM_RG_OVER_VAR = "__sum_rg_over_var__"
+_SUM_INV_VAR = "__sum_inv_var__"
+_SUM_INV_SE = "__sum_inv_se__"
+
+
+@frozen
+class CollapseMultiAssayProteinsPipe(DataProcessingPipe):
+    """Combine multi-panel assay rows of the same protein into one conservatively-meta-analysed row.
+
+    duplicate_oid_to_group: for each OID that shares its UniProt with another assay, the shared
+        group key (its UniProt). OIDs absent from this map form singleton groups. Passing only the
+        duplicated OIDs keeps the map (and the task identity) small; supply it from the manifest,
+        e.g. the UniProt of every OID whose UniProt occurs more than once.
+    """
+
+    duplicate_oid_to_group: tuple[tuple[str, str], ...]
+
+    def process(self, x: narwhals.LazyFrame) -> narwhals.LazyFrame:
+        df = x.collect().to_polars()
+
+        mapping = dict(self.duplicate_oid_to_group)
+        group_expr = (
+            pl.col(PPP_RG_OID_COL).replace(mapping)
+            if mapping
+            else pl.col(PPP_RG_OID_COL)
+        )
+        collapsed = (
+            df.with_columns(group_expr.alias(_GROUP))
+            .group_by(_GROUP, maintain_order=True)
+            .agg(
+                # Representative identity: the row with the smallest OID in the group.
+                pl.col(PPP_RG_OID_COL).min().alias(PPP_RG_OID_COL),
+                pl.col(PPP_RG_GENE_COL)
+                .sort_by(PPP_RG_OID_COL)
+                .first()
+                .alias(PPP_RG_GENE_COL),
+                pl.col(PPP_RG_VARIANT_SET_COL).first().alias(PPP_RG_VARIANT_SET_COL),
+                pl.len().alias(PPP_RG_N_ASSAYS_COL),
+                (pl.col(PPP_RG_RG_COL).max() - pl.col(PPP_RG_RG_COL).min()).alias(
+                    PPP_RG_RG_SPREAD_COL
+                ),
+                # Conservative (perfect-correlation) inverse-variance combination.
+                (pl.col(PPP_RG_RG_COL) / pl.col(PPP_RG_RG_SE_COL) ** 2)
+                .sum()
+                .alias(_SUM_RG_OVER_VAR),
+                (1.0 / pl.col(PPP_RG_RG_SE_COL) ** 2).sum().alias(_SUM_INV_VAR),
+                (1.0 / pl.col(PPP_RG_RG_SE_COL)).sum().alias(_SUM_INV_SE),
+                # Secondary diagnostics: averaged across assays (h2_trait is constant per run).
+                pl.col(PPP_RG_GCOV_COL).mean().alias(PPP_RG_GCOV_COL),
+                pl.col(PPP_RG_GCOV_INTERCEPT_COL)
+                .mean()
+                .alias(PPP_RG_GCOV_INTERCEPT_COL),
+                pl.col(PPP_RG_H2_TRAIT_COL).first().alias(PPP_RG_H2_TRAIT_COL),
+                pl.col(PPP_RG_H2_PROTEIN_COL).mean().alias(PPP_RG_H2_PROTEIN_COL),
+                pl.col(PPP_RG_N_SNPS_COL).min().alias(PPP_RG_N_SNPS_COL),
+            )
+            .with_columns(
+                (pl.col(_SUM_RG_OVER_VAR) / pl.col(_SUM_INV_VAR)).alias(PPP_RG_RG_COL),
+                (pl.col(_SUM_INV_SE) / pl.col(_SUM_INV_VAR)).alias(PPP_RG_RG_SE_COL),
+            )
+            .drop(_GROUP, _SUM_RG_OVER_VAR, _SUM_INV_VAR, _SUM_INV_SE)
+        )
+
+        z = (collapsed[PPP_RG_RG_COL] / collapsed[PPP_RG_RG_SE_COL]).to_numpy()
+        collapsed = collapsed.with_columns(
+            pl.Series(PPP_RG_RG_P_COL, 2.0 * scipy.stats.norm.sf(np.abs(z)))
+        )
+
+        ordered = collapsed.select(
+            PPP_RG_OID_COL,
+            PPP_RG_GENE_COL,
+            PPP_RG_VARIANT_SET_COL,
+            PPP_RG_RG_COL,
+            PPP_RG_RG_SE_COL,
+            PPP_RG_RG_P_COL,
+            PPP_RG_RG_SPREAD_COL,
+            PPP_RG_N_ASSAYS_COL,
+            PPP_RG_GCOV_COL,
+            PPP_RG_GCOV_INTERCEPT_COL,
+            PPP_RG_H2_TRAIT_COL,
+            PPP_RG_H2_PROTEIN_COL,
+            PPP_RG_N_SNPS_COL,
+        ).sort(PPP_RG_RG_P_COL)
+        return narwhals.from_native(ordered).lazy()

--- a/mecfs_bio/build_system/task/pipes/drop_nan_pipe.py
+++ b/mecfs_bio/build_system/task/pipes/drop_nan_pipe.py
@@ -1,0 +1,14 @@
+import narwhals
+from attrs import frozen
+
+from mecfs_bio.build_system.task.pipes.data_processing_pipe import DataProcessingPipe
+
+
+@frozen
+class DropNanPipe(DataProcessingPipe):
+    cols: list[str]
+
+    def process(self, x: narwhals.LazyFrame) -> narwhals.LazyFrame:
+        for col in self.cols:
+            x = x.filter(~narwhals.col(col).is_nan())
+        return x

--- a/mecfs_bio/build_system/task/pipes/multiple_testing_pipe.py
+++ b/mecfs_bio/build_system/task/pipes/multiple_testing_pipe.py
@@ -1,0 +1,26 @@
+import narwhals
+import polars as pl
+from attrs import frozen
+from statsmodels.stats.multitest import multipletests
+
+from mecfs_bio.build_system.task.multiple_testing_table_task import (
+    REJECT_NULL_LABEL,
+    Method,
+)
+from mecfs_bio.build_system.task.pipes.data_processing_pipe import DataProcessingPipe
+
+
+@frozen
+class MultipleTestingPipe(DataProcessingPipe):
+    p_col: str
+    alpha: float = 0.05
+    method: Method = "bonferroni"
+    reject_name: str = REJECT_NULL_LABEL
+
+    def process(self, x: narwhals.LazyFrame) -> narwhals.LazyFrame:
+        df = x.collect().to_polars()
+        p = df[self.p_col].to_numpy()
+        reject, _, _, _ = multipletests(pvals=p, alpha=self.alpha, method=self.method)
+        reject_ser = pl.Series(name=self.reject_name, values=reject)
+        df = df.with_columns(reject_ser)
+        return narwhals.from_native(df).lazy()

--- a/mecfs_bio/build_system/task/pipes/replace_pipe.py
+++ b/mecfs_bio/build_system/task/pipes/replace_pipe.py
@@ -11,10 +11,11 @@ class ReplaceStrictPipe(DataProcessingPipe):
     target_column: str
     new_column_name: str
     replace_mapping: Mapping
+    default: narwhals.Expr | None = None
 
     def process(self, x: narwhals.LazyFrame) -> narwhals.LazyFrame:
         return x.with_columns(
             narwhals.col(self.target_column)
-            .replace_strict(self.replace_mapping)
+            .replace_strict(self.replace_mapping, default=self.default)
             .alias(self.new_column_name)
         )

--- a/mecfs_bio/constants/ppp_ldsc_constants.py
+++ b/mecfs_bio/constants/ppp_ldsc_constants.py
@@ -56,5 +56,5 @@ PPP_RG_N_BAR_PROTEIN_COL = "n_bar_protein"
 # A protein measured on several Olink panels contributes several assay rows (same UniProt,
 # different OID); the collapse combines them (see CollapseMultiAssayProteinsPipe). n_assays is
 # how many assay rows were combined; rg_spread is their max-min rg (a discordance diagnostic).
-PPP_RG_N_ASSAYS_COL = "n_assays"
-PPP_RG_RG_SPREAD_COL = "rg_spread"
+PPP_RG_N_ASSAYS_COL = "n_a"
+PPP_RG_RG_SPREAD_COL = "spr"

--- a/mecfs_bio/constants/ppp_ldsc_constants.py
+++ b/mecfs_bio/constants/ppp_ldsc_constants.py
@@ -51,3 +51,10 @@ PPP_RG_H2_PROTEIN_COL = "h2_protein"
 PPP_RG_N_SNPS_COL = "n_snps"
 PPP_RG_N_BAR_TRAIT_COL = "n_bar_trait"
 PPP_RG_N_BAR_PROTEIN_COL = "n_bar_protein"
+
+# --- Extra columns added when the per-assay rg table is collapsed to one row per protein ---
+# A protein measured on several Olink panels contributes several assay rows (same UniProt,
+# different OID); the collapse combines them (see CollapseMultiAssayProteinsPipe). n_assays is
+# how many assay rows were combined; rg_spread is their max-min rg (a discordance diagnostic).
+PPP_RG_N_ASSAYS_COL = "n_assays"
+PPP_RG_RG_SPREAD_COL = "rg_spread"

--- a/test_mecfs_bio/unit/build_system/task/test_pipe/test_cast_to_float32_pipe.py
+++ b/test_mecfs_bio/unit/build_system/task/test_pipe/test_cast_to_float32_pipe.py
@@ -1,10 +1,12 @@
 import narwhals
 import polars as pl
 
-from mecfs_bio.build_system.task.pipes.cast_to_float32_pipe import CastToFloat32Pipe
+from mecfs_bio.build_system.task.pipes.cast_to_float32_pipe import (
+    CastFloatsToFloat32Pipe,
+)
 
 
 def test_cast_to_float32():
     df = pl.DataFrame({"col": [1.4, 2.5]}, schema={"col": pl.Float64()})
-    result = CastToFloat32Pipe().process(narwhals.from_native(df).lazy())
+    result = CastFloatsToFloat32Pipe().process(narwhals.from_native(df).lazy())
     assert result.collect_schema()["col"] == narwhals.dtypes.Float32()

--- a/test_mecfs_bio/unit/build_system/task/test_pipe/test_collapse_multi_assay_proteins_pipe.py
+++ b/test_mecfs_bio/unit/build_system/task/test_pipe/test_collapse_multi_assay_proteins_pipe.py
@@ -1,0 +1,80 @@
+import narwhals
+import numpy as np
+import polars as pl
+import scipy.stats
+
+from mecfs_bio.build_system.task.pipes.collapse_multi_assay_proteins_pipe import (
+    CollapseMultiAssayProteinsPipe,
+)
+from mecfs_bio.constants.ppp_ldsc_constants import (
+    PPP_RG_GENE_COL,
+    PPP_RG_H2_PROTEIN_COL,
+    PPP_RG_N_ASSAYS_COL,
+    PPP_RG_N_SNPS_COL,
+    PPP_RG_OID_COL,
+    PPP_RG_RG_COL,
+    PPP_RG_RG_P_COL,
+    PPP_RG_RG_SE_COL,
+    PPP_RG_RG_SPREAD_COL,
+)
+
+# Columns the pipe sees (the display chain has already dropped rg_z / n_bar_* before it).
+_INPUT = {
+    PPP_RG_OID_COL: ["OID_B", "OID_A", "OID_C"],
+    PPP_RG_GENE_COL: ["TNF", "TNF", "SINGLE"],
+    "variant_set": ["all_variants", "all_variants", "all_variants"],
+    PPP_RG_RG_COL: [0.30, 0.40, 0.20],
+    PPP_RG_RG_SE_COL: [0.20, 0.10, 0.05],
+    PPP_RG_RG_P_COL: [0.1, 0.05, 0.001],  # stale per-assay p; must be recomputed
+    "gcov": [0.04, 0.05, 0.03],
+    "gcov_intercept": [0.02, 0.01, 0.005],
+    "h2_trait": [0.16, 0.16, 0.16],
+    PPP_RG_H2_PROTEIN_COL: [0.10, 0.09, 0.05],
+    PPP_RG_N_SNPS_COL: [1001, 1000, 1002],
+}
+
+
+def _run() -> pl.DataFrame:
+    nw_df = narwhals.from_native(pl.DataFrame(_INPUT)).lazy()
+    pipe = CollapseMultiAssayProteinsPipe(
+        duplicate_oid_to_group=(("OID_A", "P_TNF"), ("OID_B", "P_TNF"))
+    )
+    return pipe.process(nw_df).collect().to_polars()
+
+
+def test_duplicated_protein_is_conservatively_combined():
+    out = _run()
+    tnf = out.filter(pl.col(PPP_RG_OID_COL) == "OID_A").row(0, named=True)
+
+    # Inverse-variance combine with perfect-correlation (linearly added) SE.
+    inv_var = np.array([1 / 0.10**2, 1 / 0.20**2])
+    rg = np.array([0.40, 0.30])
+    se = np.array([0.10, 0.20])
+    expect_rg = float((rg * inv_var).sum() / inv_var.sum())
+    expect_se = float((1 / se).sum() / inv_var.sum())
+
+    assert tnf[PPP_RG_OID_COL] == "OID_A"  # representative = smallest OID
+    assert tnf[PPP_RG_GENE_COL] == "TNF"
+    assert tnf[PPP_RG_N_ASSAYS_COL] == 2
+    assert np.isclose(tnf[PPP_RG_RG_COL], expect_rg)
+    assert np.isclose(tnf[PPP_RG_RG_SE_COL], expect_se)
+    # SE is never smaller than the most precise single assay (no manufactured precision).
+    assert tnf[PPP_RG_RG_SE_COL] >= se.min()
+    assert np.isclose(tnf[PPP_RG_RG_SPREAD_COL], 0.10)
+    expect_p = float(2.0 * scipy.stats.norm.sf(abs(expect_rg / expect_se)))
+    assert np.isclose(tnf[PPP_RG_RG_P_COL], expect_p)
+    # Diagnostics: averaged h2_protein, min n_snps.
+    assert np.isclose(tnf[PPP_RG_H2_PROTEIN_COL], 0.095)
+    assert tnf[PPP_RG_N_SNPS_COL] == 1000
+
+
+def test_singleton_protein_passes_through_unchanged():
+    out = _run()
+    single = out.filter(pl.col(PPP_RG_OID_COL) == "OID_C").row(0, named=True)
+
+    assert single[PPP_RG_N_ASSAYS_COL] == 1
+    assert np.isclose(single[PPP_RG_RG_COL], 0.20)
+    assert np.isclose(single[PPP_RG_RG_SE_COL], 0.05)
+    assert np.isclose(single[PPP_RG_RG_SPREAD_COL], 0.0)
+    expect_p = float(2.0 * scipy.stats.norm.sf(abs(0.20 / 0.05)))
+    assert np.isclose(single[PPP_RG_RG_P_COL], expect_p)

--- a/test_mecfs_bio/unit/build_system/task/test_pipe/test_multiple_testing_pipe.py
+++ b/test_mecfs_bio/unit/build_system/task/test_pipe/test_multiple_testing_pipe.py
@@ -1,0 +1,19 @@
+import narwhals
+import numpy as np
+import polars as pl
+
+from mecfs_bio.build_system.task.multiple_testing_table_task import REJECT_NULL_LABEL
+from mecfs_bio.build_system.task.pipes.multiple_testing_pipe import MultipleTestingPipe
+
+
+def test_multiple_testing_pipe():
+    df = pl.DataFrame({"p": [0.000001, 0.05, 1]})
+    result = (
+        MultipleTestingPipe("p")
+        .process(narwhals.from_native(df).lazy())
+        .collect()
+        .to_polars()
+    )
+    np.testing.assert_allclose(
+        result[REJECT_NULL_LABEL].to_numpy(), np.array([True, False, False])
+    )

--- a/test_mecfs_bio/unit/build_system/task/test_pipe/test_replace_pipe.py
+++ b/test_mecfs_bio/unit/build_system/task/test_pipe/test_replace_pipe.py
@@ -1,0 +1,22 @@
+import narwhals
+import numpy as np
+import polars as pl
+
+from mecfs_bio.build_system.task.pipes.replace_pipe import ReplaceStrictPipe
+
+
+def test_replace_pipe():
+    df = pl.DataFrame({"col": [float("nan"), 1.5]})
+    result = (
+        ReplaceStrictPipe(
+            target_column="col",
+            new_column_name="col",
+            replace_mapping={float("nan"): 1},
+            default=narwhals.col("col"),
+        )
+        .process(narwhals.from_native(df).lazy())
+        .collect()
+        .to_polars()
+    )
+
+    np.testing.assert_allclose(result["col"].to_numpy(), np.array([1, 1.5]))


### PR DESCRIPTION
- Problem: In the uk biobank pharma proteomics project, there are several instances where the same protein is assayed multiple times as a control.
- This results in multiple rows referring to the same gene/protein in the output table, which would likely be confusing to the reader.
- To correct this issue, I used claude to add a Pipe CollapseMultiAssayProteinsPipe that will merge these into a single row in the output.
- I also made a number of other adjustments to the Task to generate the table for displaying the ppp rg results to improve clarity
- 