### PR TITLE
Fig download improvements

### DIFF
--- a/experiments/claude/figure_download_benchmark/RESULTS.md
+++ b/experiments/claude/figure_download_benchmark/RESULTS.md
@@ -1,0 +1,44 @@
+# Figure-download benchmark results
+
+Run: 2026-07-24, 137 unique manifest assets, 3 reps each, into a fresh temp
+dir per run. Wall-clock seconds (log: `experiments/claude/logs/figure_download_benchmark.log`).
+
+| config                | median | min  | max  |
+|-----------------------|-------:|-----:|-----:|
+| per_asset_parallel_w8 |   18.1 | 16.4 | 19.7 |  ← current production path
+| chunked_c20_w4        |    3.0 |  2.9 |  3.0 |  ← ~6x faster
+| chunked_c20_w1        |    9.8 |  9.5 | 11.7 |
+| chunked_all_w1_bulk   |    5.1 |  4.9 |  5.7 |
+
+## Findings
+
+1. **The chunked batch is far faster, not slower.** My earlier prediction
+   (bulk/serial would lose to 8-way parallelism) was wrong in effect. Even the
+   *fully serial* chunked run (c20_w1, 7 sequential batches) beats the 8-way
+   parallel per-asset path (9.8s vs 18.1s).
+
+2. **Reason: per-invocation overhead dominates.** Each `gh release download
+   --pattern <one>` pays `gh` process startup + a full release-asset-list
+   lookup just to locate one blob. The current path pays that 137 times.
+   Chunking amortizes it: c20 pays it ~7 times, bulk pays it once.
+
+3. **gh has no internal download parallelism.** The single bulk call (5.1s) is
+   slower than 4 parallel chunks of 20 (3.0s), so within one invocation gh
+   downloads its matched assets serially. Splitting into a few parallel chunks
+   recovers concurrency on the actual transfers while keeping listing overhead
+   near-zero.
+
+4. **API pressure — the thing that provokes the HTTP 500s — drops sharply.**
+   ~7 asset-list lookups (c20_w4) instead of 137, so far less burst against
+   GitHub.
+
+## Recommendation
+
+`chunked_c20_w4` is the clear winner on every axis: ~6x faster wall-clock,
+~20x fewer asset-list API calls, and with per-chunk retry the failure blast
+radius is one ~20-asset chunk (re-downloaded with `--clobber`) rather than the
+whole run. Manifest-membership is still exact (one `--pattern <hash>` per
+manifest asset), so the CI consistency check is preserved.
+
+Chunk size / worker count are mild knobs; c20/w4 is a good default. Larger
+`chunk_workers` reintroduces the burst we're trying to avoid, so keep it small.

--- a/experiments/claude/figure_download_benchmark/benchmark.py
+++ b/experiments/claude/figure_download_benchmark/benchmark.py
@@ -1,0 +1,156 @@
+"""
+Benchmark two strategies for pulling the figure blobs from the GitHub release.
+
+Strategy A (current production path): one `gh release download --pattern <hash>`
+invocation per asset, run in a thread pool. Each invocation re-lists the
+release's assets before downloading its one blob.
+
+Strategy B (chunked batch): split the manifest's assets into chunks and issue a
+single `gh release download` per chunk with one repeated `-p <hash>` per asset,
+so a chunk is located with a single asset-list lookup. Chunks themselves are run
+in a small thread pool.
+
+Both strategies download exactly the manifest's assets (never the release's
+orphaned/old blobs), so the manifest-consistency guarantee is preserved.
+
+Each configuration is timed into a fresh temp dir and verified to have produced
+every requested blob. Wall-clock is reported as the median over repetitions to
+blunt network variance.
+
+Run: pixi r python experiments/claude/figure_download_benchmark/benchmark.py
+"""
+
+import statistics
+import tempfile
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import structlog
+from attrs import frozen
+
+from mecfs_bio.constants.gh_constants import GH_REPO_NAME
+from mecfs_bio.figures.fig_constants import (
+    FIGURE_GITHUB_RELEASE_TAG,
+    FIGURE_MANIFEST_PATH,
+)
+from mecfs_bio.figures.manifest import FigureManifest
+from mecfs_bio.util.github_commands.upload_download import download_release_asset
+from mecfs_bio.util.subproc.run_command import execute_command_with_retries
+
+logger = structlog.get_logger()
+
+REPETITIONS = 3
+
+
+def _unique_assets() -> list[str]:
+    manifest = FigureManifest.load(FIGURE_MANIFEST_PATH)
+    # Preserve order but de-duplicate (two figures can share a hash).
+    seen: dict[str, None] = {}
+    for h in manifest.figures.values():
+        seen.setdefault(h, None)
+    return list(seen.keys())
+
+
+def download_per_asset_parallel(
+    assets: list[str], dest: Path, workers: int
+) -> None:
+    def _one(asset: str) -> None:
+        download_release_asset(
+            release_tag=FIGURE_GITHUB_RELEASE_TAG,
+            repo_name=GH_REPO_NAME,
+            asset_name=asset,
+            dest=dest / asset,
+            use_gh_cli=True,
+        )
+
+    with ThreadPoolExecutor(max_workers=min(workers, len(assets))) as pool:
+        list(pool.map(_one, assets))
+
+
+def download_chunked_batch(
+    assets: list[str], dest: Path, chunk_size: int, chunk_workers: int
+) -> None:
+    chunks = [assets[i : i + chunk_size] for i in range(0, len(assets), chunk_size)]
+
+    def _one_chunk(chunk: list[str]) -> None:
+        cmd = ["gh", "release", "download", FIGURE_GITHUB_RELEASE_TAG]
+        for asset in chunk:
+            cmd += ["--pattern", asset]
+        cmd += ["--dir", str(dest), "--clobber", "-R", GH_REPO_NAME]
+        execute_command_with_retries(cmd)
+
+    with ThreadPoolExecutor(max_workers=min(chunk_workers, len(chunks))) as pool:
+        list(pool.map(_one_chunk, chunks))
+
+
+@frozen
+class Config:
+    name: str
+    run: object  # callable (assets, dest) -> None
+
+    def execute(self, assets: list[str], dest: Path) -> None:
+        self.run(assets, dest)  # type: ignore[operator]
+
+
+def _verify(dest: Path, assets: list[str]) -> None:
+    missing = [a for a in assets if not (dest / a).is_file()]
+    assert not missing, f"{len(missing)} assets missing after download: {missing[:3]}"
+
+
+def time_config(config: Config, assets: list[str]) -> float:
+    with tempfile.TemporaryDirectory() as tmp:
+        dest = Path(tmp)
+        start = time.monotonic()
+        config.execute(assets, dest)
+        elapsed = time.monotonic() - start
+        _verify(dest, assets)
+    return elapsed
+
+
+def main() -> None:
+    assets = _unique_assets()
+    logger.info(f"Benchmarking with {len(assets)} unique assets, {REPETITIONS} reps.")
+
+    configs = [
+        Config(
+            "per_asset_parallel_w8",
+            lambda a, d: download_per_asset_parallel(a, d, workers=8),
+        ),
+        Config(
+            "chunked_c20_w4",
+            lambda a, d: download_chunked_batch(a, d, chunk_size=20, chunk_workers=4),
+        ),
+        Config(
+            "chunked_c20_w1",
+            lambda a, d: download_chunked_batch(a, d, chunk_size=20, chunk_workers=1),
+        ),
+        Config(
+            "chunked_all_w1_bulk",
+            lambda a, d: download_chunked_batch(
+                a, d, chunk_size=len(a), chunk_workers=1
+            ),
+        ),
+    ]
+
+    results: dict[str, list[float]] = {}
+    for config in configs:
+        times = []
+        for rep in range(REPETITIONS):
+            elapsed = time_config(config, assets)
+            logger.info(f"{config.name} rep {rep + 1}: {elapsed:.1f}s")
+            times.append(elapsed)
+        results[config.name] = times
+
+    print("\n=== SUMMARY (wall-clock seconds) ===")
+    print(f"{'config':<26} {'median':>8} {'min':>8} {'max':>8}  runs")
+    for name, times in results.items():
+        print(
+            f"{name:<26} {statistics.median(times):>8.1f} "
+            f"{min(times):>8.1f} {max(times):>8.1f}  "
+            f"{[round(t, 1) for t in times]}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/mecfs_bio/figures/key_scripts/pull_figures.py
+++ b/mecfs_bio/figures/key_scripts/pull_figures.py
@@ -9,7 +9,7 @@ not listed in the manifest are left alone unless ``prune=True`` is passed.
 
 import shutil
 import tempfile
-from pathlib import Path
+from pathlib import Path, PurePath
 
 import structlog
 
@@ -59,7 +59,7 @@ def pull_figures(
     if not manifest.figures:
         logger.debug(f"Manifest {manifest_path} is empty; nothing to download.")
 
-    to_download: list[tuple[Path, str]] = []
+    to_download: list[tuple[PurePath, str]] = []
     for rel_path, expected_hash in manifest.figures.items():
         dest = fig_dir / rel_path
         if dest.is_file() and sha256_of_file(dest) == expected_hash:
@@ -83,7 +83,7 @@ def pull_figures(
 
 
 def _download_blobs(
-    to_download: list[tuple[Path, str]],
+    to_download: list[tuple[PurePath, str]],
     tag: str,
     repo_name: str,
     fig_dir: Path,
@@ -148,7 +148,7 @@ def _stage_assets_individually(
 
 
 def _place_staged_blobs(
-    to_download: list[tuple[Path, str]],
+    to_download: list[tuple[PurePath, str]],
     staging_dir: Path,
     fig_dir: Path,
 ) -> None:
@@ -170,7 +170,7 @@ def _prune_unmanifested(fig_dir: Path, manifest: FigureManifest) -> None:
     for path in fig_dir.rglob("*"):
         if not path.is_file():
             continue
-        rel = path.relative_to(fig_dir)
+        rel = PurePath(path.relative_to(fig_dir))
         if rel not in managed:
             logger.debug(f"Pruning {rel} (not in manifest).")
             path.unlink()

--- a/mecfs_bio/figures/key_scripts/pull_figures.py
+++ b/mecfs_bio/figures/key_scripts/pull_figures.py
@@ -7,7 +7,8 @@ is missing or has a different hash. Files under the figure directory that are
 not listed in the manifest are left alone unless ``prune=True`` is passed.
 """
 
-from concurrent.futures import ThreadPoolExecutor, as_completed
+import shutil
+import tempfile
 from pathlib import Path
 
 import structlog
@@ -21,14 +22,18 @@ from mecfs_bio.figures.fig_constants import (
 from mecfs_bio.figures.manifest import FigureManifest, sha256_of_file
 from mecfs_bio.util.github_commands.upload_download import (
     download_release_asset,
+    download_release_assets_chunked,
 )
 
 logger = structlog.get_logger()
 
-# Parallel workers for the release-download phase. As with the upload
-# path, per-call latency is dominated by `gh` CLI startup + network
-# round-trip, so a small pool gives a big speedup.
-DEFAULT_DOWNLOAD_WORKERS = 8
+# Chunked-download tuning. Each chunk is a single `gh release download` call
+# with one repeated --pattern per asset; a small pool of chunks runs
+# concurrently. This amortizes gh's per-call startup + asset-listing overhead
+# (benchmarked ~6x faster than per-asset parallel downloads, with far fewer
+# API calls); see experiments/claude/figure_download_benchmark.
+DEFAULT_CHUNK_SIZE = 20
+DEFAULT_CHUNK_WORKERS = 4
 
 
 def pull_figures(
@@ -38,7 +43,8 @@ def pull_figures(
     manifest_path: Path = FIGURE_MANIFEST_PATH,
     use_gh_cli: bool = True,
     prune: bool = False,
-    max_workers: int = DEFAULT_DOWNLOAD_WORKERS,
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
+    chunk_workers: int = DEFAULT_CHUNK_WORKERS,
 ):
     """
     Sync the local figure directory with the manifest by downloading any
@@ -62,50 +68,101 @@ def pull_figures(
         to_download.append((rel_path, expected_hash))
 
     if to_download:
-        _download_blobs_in_parallel(
+        _download_blobs(
             to_download=to_download,
             tag=tag,
             repo_name=repo_name,
             fig_dir=fig_dir,
             use_gh_cli=use_gh_cli,
-            max_workers=max_workers,
+            chunk_size=chunk_size,
+            chunk_workers=chunk_workers,
         )
 
     if prune:
         _prune_unmanifested(fig_dir=fig_dir, manifest=manifest)
 
 
-def _download_blobs_in_parallel(
+def _download_blobs(
     to_download: list[tuple[Path, str]],
     tag: str,
     repo_name: str,
     fig_dir: Path,
     use_gh_cli: bool,
-    max_workers: int,
+    chunk_size: int,
+    chunk_workers: int,
 ) -> None:
-    def _download_one(rel_path: Path, expected_hash: str) -> None:
-        dest = fig_dir / rel_path
-        logger.debug(f"Fetching {rel_path} (asset {expected_hash}) from release {tag}.")
+    """
+    Stage every needed blob (deduplicated by hash) into a temp directory, then
+    place each into ``fig_dir`` at its manifest path, verifying its hash.
+
+    Blobs are keyed by content hash, so two manifest entries that share a hash
+    are downloaded once and copied to both destinations.
+    """
+    # dict.fromkeys deduplicates while preserving order.
+    unique_hashes = list(dict.fromkeys(h for _, h in to_download))
+    logger.debug(
+        f"Downloading {len(unique_hashes)} unique blobs for "
+        f"{len(to_download)} figure(s)."
+    )
+    with tempfile.TemporaryDirectory() as staging:
+        staging_dir = Path(staging)
+        if use_gh_cli:
+            download_release_assets_chunked(
+                release_tag=tag,
+                repo_name=repo_name,
+                asset_names=unique_hashes,
+                dest_dir=staging_dir,
+                chunk_size=chunk_size,
+                chunk_workers=chunk_workers,
+            )
+        else:
+            _stage_assets_individually(
+                asset_names=unique_hashes,
+                staging_dir=staging_dir,
+                tag=tag,
+                repo_name=repo_name,
+            )
+        _place_staged_blobs(
+            to_download=to_download, staging_dir=staging_dir, fig_dir=fig_dir
+        )
+
+
+def _stage_assets_individually(
+    asset_names: list[str],
+    staging_dir: Path,
+    tag: str,
+    repo_name: str,
+) -> None:
+    """
+    Fallback path for ``use_gh_cli=False``: download each blob by URL (no gh,
+    no auth) into the staging dir. The chunked --pattern trick is gh-only.
+    """
+    for asset_name in asset_names:
         download_release_asset(
             release_tag=tag,
             repo_name=repo_name,
-            asset_name=expected_hash,
-            dest=dest,
-            use_gh_cli=use_gh_cli,
-        )
-        actual = sha256_of_file(dest)
-        assert actual == expected_hash, (
-            f"Downloaded blob for {rel_path} hashed to {actual}, "
-            f"expected {expected_hash}"
+            asset_name=asset_name,
+            dest=staging_dir / asset_name,
+            use_gh_cli=False,
         )
 
-    workers = min(max_workers, len(to_download))
-    with ThreadPoolExecutor(max_workers=workers) as pool:
-        futures = [
-            pool.submit(_download_one, rel_path, h) for rel_path, h in to_download
-        ]
-        for fut in as_completed(futures):
-            fut.result()
+
+def _place_staged_blobs(
+    to_download: list[tuple[Path, str]],
+    staging_dir: Path,
+    fig_dir: Path,
+) -> None:
+    for rel_path, expected_hash in to_download:
+        src = staging_dir / expected_hash
+        dest = fig_dir / rel_path
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        # copyfile copies data only (no chmod/utime), avoiding cross-device and
+        # DrvFs metadata pitfalls.
+        shutil.copyfile(src, dest)
+        actual = sha256_of_file(dest)
+        assert actual == expected_hash, (
+            f"Blob for {rel_path} hashed to {actual}, expected {expected_hash}"
+        )
 
 
 def _prune_unmanifested(fig_dir: Path, manifest: FigureManifest) -> None:

--- a/mecfs_bio/figures/key_scripts/push_figures.py
+++ b/mecfs_bio/figures/key_scripts/push_figures.py
@@ -15,7 +15,7 @@ release for any past commit that still references them.
 """
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Sequence
 
 import structlog
@@ -81,7 +81,7 @@ def push_figures(
     # Collect one (rel_path, src) per unique hash that needs uploading. The
     # release is content-addressed, so even if two figure paths share the
     # same blob it gets uploaded exactly once.
-    uploads_by_sha: dict[str, tuple[Path, Path]] = {}
+    uploads_by_sha: dict[str, tuple[PurePath, Path]] = {}
     for rel_path, sha in local_manifest.figures.items():
         if sha in new_hashes and sha not in uploads_by_sha:
             uploads_by_sha[sha] = (rel_path, fig_dir / rel_path)
@@ -116,12 +116,12 @@ def push_figures(
 
 
 def _upload_blobs_in_parallel(
-    uploads_by_sha: dict[str, tuple[Path, Path]],
+    uploads_by_sha: dict[str, tuple[PurePath, Path]],
     tag: str,
     repo_name: str,
     max_workers: int,
 ) -> None:
-    def _upload_one(sha: str, rel_path: Path, src: Path) -> None:
+    def _upload_one(sha: str, rel_path: PurePath, src: Path) -> None:
         logger.debug(f"Uploading blob {sha} (from {rel_path}) to release {tag}.")
         upload_blob_to_release(
             release_tag=tag, repo_name=repo_name, asset_name=sha, src_path=src
@@ -145,7 +145,7 @@ def _merge_manifests(
     present locally; paths only in ``old`` are dropped if ``prune`` is set,
     otherwise they are preserved.
     """
-    merged: dict[Path, str] = {} if prune else dict(old.figures)
+    merged: dict[PurePath, str] = {} if prune else dict(old.figures)
     merged.update(local.figures)
     return FigureManifest(figures=merged)
 

--- a/mecfs_bio/figures/manifest.py
+++ b/mecfs_bio/figures/manifest.py
@@ -14,7 +14,7 @@ manifest JSON, where one hash must be chosen.
 
 import hashlib
 import json
-from pathlib import Path
+from pathlib import Path, PurePath
 
 import structlog
 from attrs import frozen
@@ -32,12 +32,13 @@ class FigureManifest:
     Mapping from figure path (relative to the figure directory) to the
     SHA-256 hex digest of file contents.
 
-    Keys are ``Path`` objects in memory; they are serialised as POSIX
-    strings in the on-disk JSON so the manifest is portable across
-    operating systems.
+    Keys are ``PurePath`` objects in memory: they are relative to the figure
+    directory, which is not fixed until a caller joins it, so they carry no
+    filesystem identity of their own. They are serialised as POSIX strings in
+    the on-disk JSON so the manifest is portable across operating systems.
     """
 
-    figures: dict[Path, str]
+    figures: dict[PurePath, str]
 
     @classmethod
     def empty(cls) -> "FigureManifest":
@@ -57,7 +58,7 @@ class FigureManifest:
             )
         figures = raw.get(_HASH_FIELD, {})
         assert isinstance(figures, dict)
-        return cls(figures={Path(k): v for k, v in figures.items()})
+        return cls(figures={PurePath(k): v for k, v in figures.items()})
 
     def save(self, manifest_path: Path) -> None:
         manifest_path.parent.mkdir(parents=True, exist_ok=True)
@@ -71,12 +72,12 @@ class FigureManifest:
             json.dump(payload, f, indent=2, sort_keys=False)
             f.write("\n")
 
-    def with_entry(self, rel_path: Path, sha256: str) -> "FigureManifest":
+    def with_entry(self, rel_path: PurePath, sha256: str) -> "FigureManifest":
         new = dict(self.figures)
         new[rel_path] = sha256
         return FigureManifest(figures=new)
 
-    def without_entry(self, rel_path: Path) -> "FigureManifest":
+    def without_entry(self, rel_path: PurePath) -> "FigureManifest":
         new = dict(self.figures)
         new.pop(rel_path, None)
         return FigureManifest(figures=new)
@@ -99,12 +100,12 @@ def sha256_of_file(path: Path, chunk_size: int = 1 << 16) -> str:
 def scan_figure_dir(fig_dir: Path) -> FigureManifest:
     """
     Build a manifest by hashing every file under ``fig_dir`` recursively.
-    Paths are stored as ``Path`` objects relative to ``fig_dir``.
+    Paths are stored as ``PurePath`` objects relative to ``fig_dir``.
     """
-    figures: dict[Path, str] = {}
+    figures: dict[PurePath, str] = {}
     for path in sorted(fig_dir.rglob("*")):
         if not path.is_file():
             continue
-        rel = path.relative_to(fig_dir)
+        rel = PurePath(path.relative_to(fig_dir))
         figures[rel] = sha256_of_file(path)
     return FigureManifest(figures=figures)

--- a/mecfs_bio/figures/manifest_validation.py
+++ b/mecfs_bio/figures/manifest_validation.py
@@ -10,7 +10,7 @@ already in the figure directory) but fail for any collaborator who has to
 pull and regenerate from scratch. This module catches that drift.
 """
 
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Iterable, Sequence
 
 from mecfs_bio.build_system.task.base_task import Task
@@ -27,10 +27,10 @@ class ManifestTaskMismatchError(ValueError):
 
 
 def find_orphan_paths(
-    paths: Iterable[Path],
+    paths: Iterable[PurePath],
     tasks: Sequence[Task],
     fig_dir: Path,
-) -> list[Path]:
+) -> list[PurePath]:
     """
     Return the paths in ``paths`` that no task in ``tasks`` produces.
 
@@ -42,19 +42,19 @@ def find_orphan_paths(
     for validation, or the union of manifest keys and on-disk files for
     pruning. Result is sorted for stable error messages and pruning order.
     """
-    file_destinations: set[Path] = set()
-    dir_destinations: list[Path] = []
+    file_destinations: set[PurePath] = set()
+    dir_destinations: list[PurePath] = []
     for task in tasks:
         meta = task.meta
         assert isinstance(meta, ValidFigureMeta)
         dst = get_figure_destination(meta=meta, fig_dir=fig_dir)
-        rel = dst.relative_to(fig_dir)
+        rel = PurePath(dst.relative_to(fig_dir))
         if isinstance(meta, DirectoryFigureMeta):
             dir_destinations.append(rel)
         else:
             file_destinations.add(rel)
 
-    orphan_paths: list[Path] = []
+    orphan_paths: list[PurePath] = []
     for path in paths:
         if path in file_destinations:
             continue

--- a/mecfs_bio/figures/orphan_pruning.py
+++ b/mecfs_bio/figures/orphan_pruning.py
@@ -12,7 +12,7 @@ doc references).
 """
 
 import shutil
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Sequence
 
 import structlog
@@ -31,7 +31,7 @@ class OrphanReferencedInDocsError(ValueError):
 
 
 def find_doc_references(
-    rel_path: Path, docs_dir: Path, fig_dir_name: str
+    rel_path: PurePath, docs_dir: Path, fig_dir_name: str
 ) -> list[Path]:
     """
     Return every ``.md`` file under ``docs_dir`` whose contents mention
@@ -95,9 +95,9 @@ def prune_orphan_figures(
         logger.debug("No orphan figure-manifest entries to prune.")
         return
 
-    blockers_present: dict[Path, list[Path]] = {}
-    blockers_missing: dict[Path, list[Path]] = {}
-    safe_to_remove: list[Path] = []
+    blockers_present: dict[PurePath, list[Path]] = {}
+    blockers_missing: dict[PurePath, list[Path]] = {}
+    safe_to_remove: list[PurePath] = []
     for rel_path in orphans:
         refs = find_doc_references(
             rel_path=rel_path, docs_dir=docs_dir, fig_dir_name=fig_dir.name
@@ -138,8 +138,8 @@ def prune_orphan_figures(
 
 
 def _format_blocked_message(
-    blockers_present: dict[Path, list[Path]],
-    blockers_missing: dict[Path, list[Path]],
+    blockers_present: dict[PurePath, list[Path]],
+    blockers_missing: dict[PurePath, list[Path]],
 ) -> str:
     lines = [
         "Cannot prune figure manifest: the following entries are not "

--- a/mecfs_bio/util/github_commands/upload_download.py
+++ b/mecfs_bio/util/github_commands/upload_download.py
@@ -8,7 +8,10 @@ from subprocess import CalledProcessError
 import structlog
 
 from mecfs_bio.util.download.robust_download import robust_download_with_aria
-from mecfs_bio.util.subproc.run_command import execute_command
+from mecfs_bio.util.subproc.run_command import (
+    execute_command,
+    execute_command_with_retries,
+)
 
 logger = structlog.get_logger()
 
@@ -246,10 +249,11 @@ def download_release_asset(
                 asset_name,
                 "--dir",
                 str(tmp_dir),
+                "--clobber",
                 "-R",
                 repo_name,
             ]
-            execute_command(cmd)
+            execute_command_with_retries(cmd)
             downloaded = tmp_dir / asset_name
             assert downloaded.is_file(), (
                 f"gh did not produce {downloaded} for asset {asset_name}"

--- a/mecfs_bio/util/github_commands/upload_download.py
+++ b/mecfs_bio/util/github_commands/upload_download.py
@@ -2,6 +2,7 @@ import json
 import shutil
 import tempfile
 import zipfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from subprocess import CalledProcessError
 
@@ -224,6 +225,55 @@ def upload_blob_to_release(
             repo_name,
         ]
         execute_command(cmd=cmd)
+
+
+def download_release_assets_chunked(
+    release_tag: str,
+    repo_name: str,
+    asset_names: list[str],
+    dest_dir: Path,
+    chunk_size: int = 20,
+    chunk_workers: int = 4,
+) -> None:
+    """
+    Download many named assets from a release into dest_dir, writing one file
+    per asset name.
+
+    Assets are fetched in chunks: each chunk is a single gh release download
+    invocation with one repeated --pattern per asset name, which amortizes gh's
+    per-call process startup and release-asset-list lookup over the whole chunk
+    (a per-asset invocation pays both costs once per asset). A small pool of
+    chunks runs concurrently, since gh downloads a chunk's assets serially.
+    Each chunk invocation is retried with backoff to absorb the transient
+    GitHub HTTP 500s that the per-asset burst used to surface as hard failures.
+
+    Benchmarked at ~6x faster than per-asset parallel downloads with ~20x fewer
+    asset-list API calls; see experiments/claude/figure_download_benchmark.
+    """
+    assert chunk_size >= 1, f"chunk_size must be >= 1, got {chunk_size}"
+    assert chunk_workers >= 1, f"chunk_workers must be >= 1, got {chunk_workers}"
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    chunks = [
+        asset_names[i : i + chunk_size] for i in range(0, len(asset_names), chunk_size)
+    ]
+
+    def _download_chunk(chunk: list[str]) -> None:
+        cmd = ["gh", "release", "download", release_tag]
+        for asset_name in chunk:
+            cmd += ["--pattern", asset_name]
+        cmd += ["--dir", str(dest_dir), "--clobber", "-R", repo_name]
+        execute_command_with_retries(cmd)
+        for asset_name in chunk:
+            asset_path = dest_dir / asset_name
+            assert asset_path.is_file(), (
+                f"gh did not produce {asset_path} for asset {asset_name}"
+            )
+
+    workers = min(chunk_workers, len(chunks))
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = [pool.submit(_download_chunk, chunk) for chunk in chunks]
+        for fut in as_completed(futures):
+            fut.result()
 
 
 def download_release_asset(

--- a/mecfs_bio/util/subproc/run_command.py
+++ b/mecfs_bio/util/subproc/run_command.py
@@ -1,5 +1,8 @@
+import random
 import subprocess
 import sys
+import time
+from collections.abc import Callable
 from subprocess import CalledProcessError
 
 import structlog
@@ -40,3 +43,41 @@ def execute_command(cmd: list[str]) -> str:
             return output
         else:
             raise CalledProcessError(cmd=cmd, returncode=p.returncode, output=output)
+
+
+def execute_command_with_retries(
+    cmd: list[str],
+    max_attempts: int = 6,
+    base_backoff_seconds: float = 2.0,
+    max_backoff_seconds: float = 60.0,
+    sleep: Callable[[float], None] = time.sleep,
+    executor: Callable[[list[str]], str] = execute_command,
+) -> str:
+    """
+    Run a command, retrying on CalledProcessError with exponential backoff
+    and jitter.
+
+    Intended for commands that hit flaky remote services (e.g. the GitHub
+    release API, which intermittently returns HTTP 500 on asset downloads).
+    The final failure is re-raised so callers still fail loudly on a genuinely
+    broken command. The sleep and executor functions are injectable so tests
+    can supply their own implementations without real delays or subprocesses.
+    """
+    assert max_attempts >= 1, f"max_attempts must be >= 1, got {max_attempts}"
+    last_error: CalledProcessError | None = None
+    for attempt in range(max_attempts):
+        try:
+            return executor(cmd)
+        except CalledProcessError as e:
+            last_error = e
+            if attempt >= max_attempts - 1:
+                break
+            capped = min(base_backoff_seconds * 2**attempt, max_backoff_seconds)
+            backoff = random.uniform(0, capped)
+            logger.debug(
+                f"Command failed (attempt {attempt + 1}/{max_attempts}, "
+                f"exit {e.returncode}). Backing off {backoff:.1f}s before retry."
+            )
+            sleep(backoff)
+    assert last_error is not None
+    raise last_error

--- a/test_mecfs_bio/unit/figures/test_orphan_pruning.py
+++ b/test_mecfs_bio/unit/figures/test_orphan_pruning.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+from pathlib import Path, PurePath
 
 import pytest
 
@@ -24,7 +24,7 @@ def _file_task(asset_id: str, extension: str = ".png") -> FakeTask:
     )
 
 
-def _write_manifest(manifest_path: Path, entries: dict[Path, str]) -> None:
+def _write_manifest(manifest_path: Path, entries: dict[PurePath, str]) -> None:
     FigureManifest(figures=entries).save(manifest_path)
 
 

--- a/test_mecfs_bio/unit/util/subproc/test_execute_command_with_retries.py
+++ b/test_mecfs_bio/unit/util/subproc/test_execute_command_with_retries.py
@@ -1,0 +1,44 @@
+from subprocess import CalledProcessError
+
+import pytest
+
+from mecfs_bio.util.subproc.run_command import execute_command_with_retries
+
+
+def test_retries_then_succeeds():
+    """A command that fails twice then succeeds is retried to success."""
+    calls = {"n": 0}
+    slept: list[float] = []
+
+    def flaky_executor(cmd: list[str]) -> str:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise CalledProcessError(returncode=1, cmd=cmd, output="HTTP 500")
+        return "ok"
+
+    result = execute_command_with_retries(
+        ["echo", "hi"],
+        base_backoff_seconds=0.0,
+        sleep=slept.append,
+        executor=flaky_executor,
+    )
+
+    assert result == "ok"
+    assert calls["n"] == 3
+    assert len(slept) == 2
+
+
+def test_reraises_after_exhausting_attempts():
+    """After max_attempts failures the last error is re-raised."""
+
+    def always_fail(cmd: list[str]) -> str:
+        raise CalledProcessError(returncode=1, cmd=cmd, output="HTTP 500")
+
+    with pytest.raises(CalledProcessError):
+        execute_command_with_retries(
+            ["echo", "hi"],
+            max_attempts=3,
+            base_backoff_seconds=0.0,
+            sleep=lambda _: None,
+            executor=always_fail,
+        )


### PR DESCRIPTION
- Problem: I have noticed flakyiness in downloading figure assets for use in documentation building.
- Solution: add a retry wrapper to the download operation.  Also, download assets in chunks, so that we do not make a huge number of calls to the github api.
- Also as a cleanup, switch to using PurePath for paths relative to an unspecified base.