### PR TITLE
Relocate asset store subdirs

### DIFF
--- a/experiments/claude/dbsnp_remap_scan_cost/measure_dbsnp_scan_cost.py
+++ b/experiments/claude/dbsnp_remap_scan_cost/measure_dbsnp_scan_cost.py
@@ -1,0 +1,91 @@
+"""
+Measure how much slower rsID assignment gets after dbSNP moved to the external drive.
+
+The rsID assignment join (annovar_37_basic_rsid_assignment) reads five columns of the
+353M-row annovar dbSNP150 parquet through a lazy duckdb scan.  After the asset store
+split, that file lives on /mnt/d instead of local ext4, so the question is how much wall
+clock the extra I/O costs.
+
+Raw dd overstates the answer, because parquet decode is CPU work that overlaps the read.
+This script measures the real scan twice:
+
+    cold pass -- data comes off /mnt/d, so the scan is bounded by whichever of I/O and
+                 decode is slower
+    warm pass -- the same bytes are served from page cache, which is the closest available
+                 proxy for the old local-disk behaviour now that the local copy is gone
+
+The difference between the two passes is the honest estimate of the regression.
+"""
+
+import subprocess
+import time
+from pathlib import Path
+
+import duckdb
+
+DBSNP_PARQUET = Path(
+    "/mnt/d/asset_store_remote/reference_data/db_snp_reference_data/build_37/annovar/"
+    "db_snp150_annovar_proc_parquet_unique_direct_download.parquet"
+)
+
+# The columns the join actually touches: right_on plus the rsid it carries through.
+JOIN_COLUMNS = ("int_chrom", "POS", "ALT", "REF", "rsid")
+
+
+def scan_join_columns(path: Path) -> tuple[int, float]:
+    """
+    Read exactly the columns the join reads, forcing full materialization of each, and
+    return the row count together with the elapsed seconds.
+
+    The aggregate must depend on the column VALUES.  count(column) is answered from the
+    parquet footer statistics without reading a single data page, which makes the query
+    finish in a fraction of a second and measures nothing.  Hashing every join key forces
+    the scan the real join performs.
+    """
+    keys = ", ".join(JOIN_COLUMNS)
+    query = (
+        f"select count(*), sum(hash({keys})::HUGEINT) from read_parquet('{path}')"
+    )
+    start = time.monotonic()
+    result = duckdb.sql(query).fetchone()
+    elapsed = time.monotonic() - start
+    assert result is not None
+    return result[0], elapsed
+
+
+def drop_page_cache_for(path: Path) -> None:
+    """
+    Evict the file from the page cache so the next read is genuinely cold.  'dd count=0
+    iflag=nocache' applies POSIX_FADV_DONTNEED to the whole file rather than to a single
+    block.
+    """
+    subprocess.run(["sync"], capture_output=True, check=False)
+    subprocess.run(
+        ["dd", f"if={path}", "of=/dev/null", "count=0", "iflag=nocache"],
+        capture_output=True,
+        check=False,
+    )
+
+
+def main() -> None:
+    size_gb = DBSNP_PARQUET.stat().st_size / 1e9
+    print(f"file: {DBSNP_PARQUET}")
+    print(f"size: {size_gb:.2f} GB")
+    print(f"columns scanned: {', '.join(JOIN_COLUMNS)}\n")
+
+    drop_page_cache_for(DBSNP_PARQUET)
+    rows, cold = scan_join_columns(DBSNP_PARQUET)
+    print(f"cold pass (served from /mnt/d):     {cold:7.1f} s   rows={rows:,}")
+
+    _, warm = scan_join_columns(DBSNP_PARQUET)
+    print(f"warm pass (served from page cache): {warm:7.1f} s")
+
+    print(
+        f"\nestimated regression per rsID assignment run: "
+        f"+{cold - warm:.1f} s ({(cold - warm) / 60:.1f} min)"
+    )
+    print(f"cold/warm ratio: {cold / warm:.1f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/mecfs_bio/analysis/runner/default_runner.py
+++ b/mecfs_bio/analysis/runner/default_runner.py
@@ -3,6 +3,15 @@ Code configuring the default runner, which is used to run the main standard anal
 
 Some of the default runner options can bet overridden by adding a yaml file at
 _DEFAULT_RUNNER_CONFIG_PATH.yaml
+
+The config is machine-local and is not checked in.  Every key is independently optional,
+so a config may set only the ones it wants to change:
+
+    asset_root:  root of the asset store
+    info_store:  path of the persistent verifying-trace cache
+    path_remap:  rules routing selected store subtrees to other filesystems, so that one
+                 logical store can span disks.  See the remapping_meta_to_path module for
+                 the schema and for guidance on which subtrees are worth remapping.
 """
 
 import functools
@@ -11,6 +20,9 @@ from pathlib import Path
 import structlog
 import yaml
 
+from mecfs_bio.build_system.rebuilder.metadata_to_path.remapping_meta_to_path import (
+    PathRemapRule,
+)
 from mecfs_bio.build_system.rebuilder.verifying_trace_rebuilder.tracer.imohash import (
     ImoHasher,
 )
@@ -30,6 +42,7 @@ _DEFAULT_RUNNER_CONFIG_PATH = Path("default_runner_config.yaml")
 
 _ASSET_ROOT_KEY = "asset_root"
 _INFO_STORE_KEY = "info_store"
+_PATH_REMAP_KEY = "path_remap"
 
 
 @functools.cache
@@ -50,20 +63,28 @@ def load_runner_config() -> dict | None:
 
 def _get_asset_root_path() -> Path:
     config = load_runner_config()
-    if config is None:
+    if config is None or _ASSET_ROOT_KEY not in config:
         return ASSET_ROOT
     return Path(config[_ASSET_ROOT_KEY])
 
 
 def _get_info_store_path() -> Path:
     config = load_runner_config()
-    if config is None:
+    if config is None or _INFO_STORE_KEY not in config:
         return IMO_128_INFO_STORE_PATH
     return Path(config[_INFO_STORE_KEY])
+
+
+def get_path_remap_rules() -> tuple[PathRemapRule, ...]:
+    config = load_runner_config()
+    if config is None or _PATH_REMAP_KEY not in config:
+        return ()
+    return PathRemapRule.tuple_from_config(config[_PATH_REMAP_KEY])
 
 
 DEFAULT_RUNNER = SimpleRunner(
     tracer=_imo_hasher_128,  # _imo_hasher_32,#SimpleHasher.md5_hasher(),
     info_store=_get_info_store_path(),  # IMO_32_INFO_STORE_PATH,#MD5_INFO_STORE_PATH,
     asset_root=_get_asset_root_path(),
+    path_remap=get_path_remap_rules(),
 )

--- a/mecfs_bio/build_system/rebuilder/metadata_to_path/remapping_meta_to_path.py
+++ b/mecfs_bio/build_system/rebuilder/metadata_to_path/remapping_meta_to_path.py
@@ -1,0 +1,214 @@
+"""
+Spread one logical asset store across several filesystems.
+
+Motivation: the asset store outgrows the disk it lives on long before the machine runs
+out of storage in total.  Relocating the whole store to a large external drive is a bad
+trade, because such drives are usually reached over a mount whose dominant cost is
+per-file latency rather than bulk throughput.  Subtrees made of thousands of small files
+become painfully slow there, while a subtree of a few enormous files is barely affected.
+
+The remedy is to route individual subtrees, not the whole store.  Because
+simple_meta_to_relative_path is root-free, an asset's location is a root plus a fixed
+relative path, so routing is entirely a question of which root to prepend.
+
+Choosing what to remap: prefer subtrees that are large, made of FEW files, and read
+infrequently.  Measured examples from this repo's own store show how far apart the two
+extremes sit:
+
+    reference_data/db_snp_reference_data      85G in 9 files       ideal to remap
+    reference_data/genome_annotations         21G in 2 files       ideal to remap
+    reference_data/linkage_disequilibrium_scores
+                                              51G in 186,105 files must stay local
+
+Two consequences worth knowing before remapping a subtree:
+
+    Finalizing a remapped asset is no longer an instant os.rename.  sandboxed_execute
+    builds into a scratch directory on the local disk, so moving the result to a remapped
+    root crosses a filesystem boundary and falls back to _cross_device_move, which copies
+    every byte.  This is correct but slow, and is a further reason to remap only subtrees
+    that are rarely rebuilt.
+
+    Remapping lowers steady-state usage of the default root, not peak usage.  The scratch
+    directory still lives on the local disk, so building a large remapped asset still
+    needs transient room for it there.  TMPDIR is the separate knob for that.
+
+Relocating an asset does not invalidate the build cache: verifying traces are content
+hashes and carry no location.  Moving the config without moving the files, however, makes
+existing assets invisible to get_asset_if_exists and forces a rebuild, so a rule change
+must be paired with an actual migration of the data.
+"""
+
+from pathlib import Path, PurePath
+from typing import Any, Callable, Mapping, Sequence
+
+import structlog
+from attrs import frozen
+
+from mecfs_bio.build_system.meta.meta import Meta
+from mecfs_bio.build_system.rebuilder.metadata_to_path.base_meta_to_path import (
+    MetaToPath,
+)
+from mecfs_bio.build_system.rebuilder.metadata_to_path.simple_meta_to_path import (
+    simple_meta_to_relative_path,
+)
+
+logger = structlog.get_logger(__name__)
+
+_ROOT_KEY = "root"
+_PREFIXES_KEY = "prefixes"
+_ALLOWED_RULE_KEYS = frozenset({_ROOT_KEY, _PREFIXES_KEY})
+
+# Repo-level command that reconciles the store on disk with the configured rules.
+MIGRATE_COMMAND = "pixi r invoke migrate-asset-store"
+
+
+@frozen
+class PathRemapRule:
+    """
+    Send every asset whose store-relative path starts with one of prefixes to root
+    instead of to the default store root.
+
+    In yaml, as consumed from default_runner_config.yaml:
+
+        path_remap:
+          - root: /mnt/d/asset_store_remote
+            prefixes:
+              - reference_data/db_snp_reference_data
+              - reference_data/genome_annotations
+
+    A prefix is matched component-wise, never as a string prefix, so a rule on
+    reference_data/db_snp does not also capture reference_data/db_snp_extra.
+
+    Prefixes are ordinary store-relative paths, so any level of the layout can be
+    selected.  gwas/<trait> works just as well as reference_data/<group>, which makes it
+    possible to archive a trait that is no longer under active analysis.
+    """
+
+    root: Path
+    prefixes: tuple[PurePath, ...]
+
+    def __attrs_post_init__(self) -> None:
+        assert self.prefixes, f"Remap rule for root {self.root} lists no prefixes."
+        for prefix in self.prefixes:
+            assert prefix.parts, (
+                f"Empty remap prefix for root {self.root}; a prefix must select a subtree."
+            )
+            assert not prefix.is_absolute(), (
+                f"Remap prefix {prefix} must be relative to the asset store root, "
+                f"not absolute."
+            )
+
+    def matches(self, relative: PurePath) -> bool:
+        return any(
+            relative.parts[: len(prefix.parts)] == prefix.parts
+            for prefix in self.prefixes
+        )
+
+    @classmethod
+    def tuple_from_config(
+        cls, entries: Sequence[Mapping[str, Any]]
+    ) -> tuple["PathRemapRule", ...]:
+        """
+        Build rules from the path_remap section of a parsed yaml config.  Unrecognized
+        keys are an error rather than being ignored, so a typo in a machine-local config
+        surfaces immediately instead of silently disabling a rule.
+        """
+        rules = []
+        for entry in entries:
+            unknown = set(entry) - _ALLOWED_RULE_KEYS
+            assert not unknown, (
+                f"Unknown key(s) {sorted(unknown)} in a path_remap entry; "
+                f"expected only {sorted(_ALLOWED_RULE_KEYS)}."
+            )
+            assert _ROOT_KEY in entry, f"path_remap entry {entry} is missing a root."
+            assert _PREFIXES_KEY in entry, (
+                f"path_remap entry {entry} is missing prefixes."
+            )
+            rules.append(
+                cls(
+                    root=Path(entry[_ROOT_KEY]),
+                    prefixes=tuple(PurePath(p) for p in entry[_PREFIXES_KEY]),
+                )
+            )
+        return tuple(rules)
+
+
+@frozen
+class RemappingMetaToPath(MetaToPath):
+    """
+    Place assets under default_root, except for those selected by a rule in rules, which
+    go under that rule's root instead.
+
+    With no rules this is exactly equivalent to SimpleMetaToPath(root=default_root).
+    """
+
+    default_root: Path
+    rules: tuple[PathRemapRule, ...]
+    relative_path: Callable[[Meta], PurePath] = simple_meta_to_relative_path
+
+    def __attrs_post_init__(self) -> None:
+        _check_prefixes_disjoint(self.rules)
+
+    def __call__(self, m: Meta) -> Path:
+        relative = self.relative_path(m)
+        for rule in self.rules:
+            if rule.matches(relative):
+                return rule.root / relative
+        return self.default_root / relative
+
+
+def _check_prefixes_disjoint(rules: Sequence[PathRemapRule]) -> None:
+    """
+    Reject rule sets in which one prefix is a prefix of another, whether within a rule or
+    across rules.  Overlapping prefixes would make an asset's location depend on rule
+    order, which is not something a config file should have to express.
+    """
+    seen: list[tuple[PurePath, Path]] = [
+        (prefix, rule.root) for rule in rules for prefix in rule.prefixes
+    ]
+    for i, (prefix, root) in enumerate(seen):
+        for other_prefix, other_root in seen[i + 1 :]:
+            shorter, longer = sorted((prefix, other_prefix), key=lambda p: len(p.parts))
+            assert longer.parts[: len(shorter.parts)] != shorter.parts, (
+                f"Remap prefixes overlap: {prefix} (root {root}) and "
+                f"{other_prefix} (root {other_root}).  One asset would match both, so "
+                f"its location would depend on rule order."
+            )
+
+
+def stale_default_root_dirs(
+    default_root: Path, rules: Sequence[PathRemapRule]
+) -> list[Path]:
+    """
+    Return the directories that are still present under default_root even though a rule
+    now routes them elsewhere.  A non-empty result means assets have not been migrated
+    and will be rebuilt rather than found.
+    """
+    return [
+        default_root / prefix
+        for rule in rules
+        for prefix in rule.prefixes
+        if (default_root / prefix).exists()
+    ]
+
+
+def warn_on_unmigrated_assets(
+    default_root: Path, rules: Sequence[PathRemapRule]
+) -> None:
+    """
+    Warn if a subtree that is now routed elsewhere still holds data under default_root.
+
+    That state means the config was changed without moving the data, so those assets are
+    invisible to the build system and will be rebuilt from scratch at the new location
+    while the old copy keeps occupying the disk the remapping was meant to relieve.
+
+    This is deliberately only a warning: aborting would strand a pipeline that may already
+    be hours into a run, and rebuilding is wasteful rather than wrong.  It costs one stat
+    per configured prefix, and nothing at all when no rules are configured.
+    """
+    for stale in stale_default_root_dirs(default_root, rules):
+        logger.warning(
+            f"Asset store subtree {stale} is still present under the default asset root "
+            f"even though path_remap now routes it elsewhere.  Those assets will be "
+            f"rebuilt rather than found.  Run '{MIGRATE_COMMAND}' to move them."
+        )

--- a/mecfs_bio/build_system/rebuilder/metadata_to_path/simple_meta_to_path.py
+++ b/mecfs_bio/build_system/rebuilder/metadata_to_path/simple_meta_to_path.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+from pathlib import Path, PurePath
 
 from attrs import frozen
 
@@ -39,143 +39,107 @@ from mecfs_bio.build_system.rebuilder.metadata_to_path.base_meta_to_path import 
     MetaToPath,
 )
 
+_GWAS = PurePath("gwas")
+_REFERENCE_DATA = PurePath("reference_data")
+_OTHER_FILES = PurePath("other_files")
+_EXECUTABLE = PurePath("executable")
+
+
+def simple_meta_to_relative_path(m: Meta) -> PurePath:
+    """
+    Compute where an asset lives inside the asset store, as a path relative to the store
+    root.
+
+    The layout is deliberately root-free so that one logical asset store can be spread
+    across several filesystems: the same relative path is simply appended to whichever
+    root the caller selects.  See the remapping_meta_to_path module for the machinery
+    that exploits this.
+    """
+    if isinstance(m, SimpleFileMeta):
+        return _OTHER_FILES / m.id
+    if isinstance(m, SimpleDirectoryMeta):
+        return _OTHER_FILES / m.asset_id
+    if isinstance(m, GWASSummaryDataFileMeta):
+        pth = _GWAS / m.trait / m.project / m.sub_dir
+        if m.project_path is not None:
+            pth = pth / m.project_path
+        else:
+            f_name = str(m.id)
+            if m.extension is not None:
+                f_name += m.extension
+            pth = pth / f_name
+        return pth
+    if isinstance(m, FilteredGWASDataMeta):
+        pth = _GWAS / m.trait / m.project / m.sub_dir / str(m.id + m.extension)
+        return pth
+    if isinstance(m, MarkdownFileMeta):
+        pth = _GWAS / m.trait / m.project / m.sub_dir / str(m.id + ".md")
+        return pth
+    if isinstance(m, ProcessedGwasDataDirectoryMeta):
+        pth = _GWAS / m.trait / m.project / m.sub_dir / str(m.id)
+        return pth
+    if isinstance(m, GWASLabSumStatsMeta):
+        pth = _GWAS / m.trait / m.project / m.sub_dir / (m.asset_id + ".pickle")
+        return pth
+    if isinstance(m, GWASLabLeadVariantsMeta):
+        pth = _GWAS / m.trait / m.project / m.sub_dir / str(m.asset_id + ".csv")
+        return pth
+    if isinstance(m, GWASLabRegionPlotsMeta):
+        pth = _GWAS / m.trait / m.project / m.sub_dir / m.asset_id
+        return pth
+    if isinstance(m, GWASLabManhattanQQPlotMeta):
+        pth = _GWAS / m.trait / m.project / m.sub_dir / str(m.asset_id + ".png")
+        return pth
+    if isinstance(m, ReferenceFileMeta):
+        pth = _REFERENCE_DATA / m.group / m.sub_group / m.sub_folder
+        if m.filename is not None:
+            pth = pth / (m.filename + m.extension)
+        else:
+            pth = pth / str(m.id + m.extension)
+        return pth
+
+    if isinstance(m, ReferenceDataDirectoryMeta):
+        dirname = m.dirname if m.dirname is not None else m.id
+        pth = _REFERENCE_DATA / m.group / m.sub_group / m.sub_folder / dirname
+        return pth
+
+    if isinstance(m, ExecutableMeta):
+        pth = _EXECUTABLE / m.group / m.sub_folder
+        if m.filename is not None:
+            fname = m.filename
+            if m.extension is not None:
+                fname += m.extension
+            pth = pth / fname
+        else:
+            pth = pth / m.id
+        return pth
+
+    if isinstance(m, (GWASPlotDirectoryMeta)):
+        pth = _GWAS / m.trait / m.project / m.sub_dir / m.asset_id
+        return pth
+
+    if isinstance(m, (GWASPlotFileMeta)):
+        pth = _GWAS / m.trait / m.project / m.sub_dir / (m.asset_id + m.extension)
+        return pth
+    if isinstance(m, ResultTableMeta):
+        pth = _GWAS / m.trait / m.project / m.sub_dir / (m.id + m.extension)
+        return pth
+    if isinstance(m, ResultDirectoryMeta):
+        pth = _GWAS / m.trait / m.project / m.sub_dir / m.id
+        return pth
+    if isinstance(m, ResultArchiveMeta):
+        pth = _GWAS / m.trait / m.project / m.sub_dir / (m.id + m.extension)
+        return pth
+    raise ValueError(f"Unknown meta {m} of type {type(m)}.")
+
 
 @frozen
 class SimpleMetaToPath(MetaToPath):
+    """
+    Place every asset under a single store root, using the standard relative layout.
+    """
+
     root: Path
 
     def __call__(self, m: Meta) -> Path:
-        if isinstance(m, SimpleFileMeta):
-            return self.root / "other_files" / m.id
-        if isinstance(m, SimpleDirectoryMeta):
-            return self.root / "other_files" / m.asset_id
-        if isinstance(m, GWASSummaryDataFileMeta):
-            pth = self.root / "gwas" / m.trait / m.project / m.sub_dir
-            if m.project_path is not None:
-                pth = pth / m.project_path
-            else:
-                f_name = str(m.id)
-                if m.extension is not None:
-                    f_name += m.extension
-                pth = pth / f_name
-            return pth
-        if isinstance(m, FilteredGWASDataMeta):
-            pth = (
-                self.root
-                / "gwas"
-                / m.trait
-                / m.project
-                / m.sub_dir
-                / str(m.id + m.extension)
-            )
-            return pth
-        if isinstance(m, MarkdownFileMeta):
-            pth = (
-                self.root / "gwas" / m.trait / m.project / m.sub_dir / str(m.id + ".md")
-            )
-            return pth
-        if isinstance(m, ProcessedGwasDataDirectoryMeta):
-            pth = self.root / "gwas" / m.trait / m.project / m.sub_dir / str(m.id)
-            return pth
-        if isinstance(m, GWASLabSumStatsMeta):
-            pth = (
-                self.root
-                / "gwas"
-                / m.trait
-                / m.project
-                / m.sub_dir
-                / (m.asset_id + ".pickle")
-            )
-            return pth
-        if isinstance(m, GWASLabLeadVariantsMeta):
-            pth = (
-                self.root
-                / "gwas"
-                / m.trait
-                / m.project
-                / m.sub_dir
-                / str(m.asset_id + ".csv")
-            )
-            return pth
-        if isinstance(m, GWASLabRegionPlotsMeta):
-            pth = self.root / "gwas" / m.trait / m.project / m.sub_dir / m.asset_id
-            return pth
-        if isinstance(m, GWASLabManhattanQQPlotMeta):
-            pth = (
-                self.root
-                / "gwas"
-                / m.trait
-                / m.project
-                / m.sub_dir
-                / str(m.asset_id + ".png")
-            )
-            return pth
-        if isinstance(m, ReferenceFileMeta):
-            pth = self.root / "reference_data" / m.group / m.sub_group / m.sub_folder
-            if m.filename is not None:
-                pth = pth / (m.filename + m.extension)
-            else:
-                pth = pth / str(m.id + m.extension)
-            return pth
-
-        if isinstance(m, ReferenceDataDirectoryMeta):
-            dirname = m.dirname if m.dirname is not None else m.id
-            pth = (
-                self.root
-                / "reference_data"
-                / m.group
-                / m.sub_group
-                / m.sub_folder
-                / dirname
-            )
-            return pth
-
-        if isinstance(m, ExecutableMeta):
-            pth = self.root / "executable" / m.group / m.sub_folder
-            if m.filename is not None:
-                fname = m.filename
-                if m.extension is not None:
-                    fname += m.extension
-                pth = pth / fname
-            else:
-                pth = pth / m.id
-            return pth
-
-        if isinstance(m, (GWASPlotDirectoryMeta)):
-            pth = self.root / "gwas" / m.trait / m.project / m.sub_dir / m.asset_id
-            return pth
-
-        if isinstance(m, (GWASPlotFileMeta)):
-            pth = (
-                self.root
-                / "gwas"
-                / m.trait
-                / m.project
-                / m.sub_dir
-                / (m.asset_id + m.extension)
-            )
-            return pth
-        if isinstance(m, ResultTableMeta):
-            pth = (
-                self.root
-                / "gwas"
-                / m.trait
-                / m.project
-                / m.sub_dir
-                / (m.id + m.extension)
-            )
-            return pth
-        if isinstance(m, ResultDirectoryMeta):
-            pth = self.root / "gwas" / m.trait / m.project / m.sub_dir / m.id
-            return pth
-        if isinstance(m, ResultArchiveMeta):
-            pth = (
-                self.root
-                / "gwas"
-                / m.trait
-                / m.project
-                / m.sub_dir
-                / (m.id + m.extension)
-            )
-            return pth
-        raise ValueError(f"Unknown meta {m} of type {type(m)}.")
+        return self.root / simple_meta_to_relative_path(m)

--- a/mecfs_bio/build_system/runner/simple_runner.py
+++ b/mecfs_bio/build_system/runner/simple_runner.py
@@ -17,6 +17,14 @@ from attrs import frozen
 
 from mecfs_bio.build_system.asset.base_asset import Asset
 from mecfs_bio.build_system.meta.asset_id import AssetId
+from mecfs_bio.build_system.rebuilder.metadata_to_path.base_meta_to_path import (
+    MetaToPath,
+)
+from mecfs_bio.build_system.rebuilder.metadata_to_path.remapping_meta_to_path import (
+    PathRemapRule,
+    RemappingMetaToPath,
+    warn_on_unmigrated_assets,
+)
 from mecfs_bio.build_system.rebuilder.metadata_to_path.simple_meta_to_path import (
     SimpleMetaToPath,
 )
@@ -50,21 +58,28 @@ class SimpleRunner:
     an execution of the workflow build system with a topological scheduler and verifying trace rebuilder
 
     info_store: path at which to store persistent cash for build-system internal information
-    asset_root: root under which to create the asset store
+    asset_root: root under which to create the asset store, and the default root for any
+        subtree not claimed by path_remap
     tracer: algorithm uses to calculate verifying traces of assets.  An example would be a hashing algorithm.  changing this forces all assets to be rebuilt
     post_execute: hook invoked after each task materialization. Defaults to running `gc.collect()` and logging RSS,
         which keeps cycle-held memory from accumulating across long pipeline runs.  Pass `noop_post_execute_hook`
         from `mecfs_bio.build_system.rebuilder.sandboxed_execute` to disable.
+    path_remap: rules sending selected store subtrees to other filesystems.  Empty by
+        default, which keeps the whole store under asset_root.  See the
+        remapping_meta_to_path module for what is worth remapping and what is not.
     """
 
     info_store: Path
     asset_root: Path
     tracer: Tracer = SimpleHasher.md5_hasher()
     post_execute: Callable[[Task], None] = gc_collect_post_execute_hook
+    path_remap: tuple[PathRemapRule, ...] = ()
 
     @property
-    def meta_to_path(self) -> SimpleMetaToPath:
-        return SimpleMetaToPath(root=self.asset_root)
+    def meta_to_path(self) -> MetaToPath:
+        if not self.path_remap:
+            return SimpleMetaToPath(root=self.asset_root)
+        return RemappingMetaToPath(default_root=self.asset_root, rules=self.path_remap)
 
     def run(
         self,
@@ -80,6 +95,7 @@ class SimpleRunner:
         returns:
         mapping from asset id to file system information for all assets that were built or retrieved as part of the execution of the scheduler
         """
+        warn_on_unmigrated_assets(self.asset_root, self.path_remap)
         if self.info_store.is_file():
             info = VerifyingTraceInfo.deserialize(self.info_store)
         else:

--- a/pixi.lock
+++ b/pixi.lock
@@ -191,6 +191,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixi-0.73.0-ha759004_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pixi-pycharm-0.0.12-unix_hf108a03_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/popt-1.19-h3b78370_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/prometheus-cpp-1.3.0-ha5d0236_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-25.0.0-py312h7900ff3_0.conda
@@ -414,6 +415,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-zoo-1.8_15-r45h54b55ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2025.11.05-h94463f1_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rsync-3.4.4-h5440a77_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rust-1.97.1-h53717f1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.97.1-h2c6d0dc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.5-h7e3ee7f_1.conda
@@ -439,6 +441,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xxhash-0.8.3-hb47aa4a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.8.3-ha02ee65_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-gpl-tools-5.8.3-ha02ee65_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-tools-5.8.3-hb03c661_0.conda
@@ -1928,7 +1931,7 @@ packages:
 - pypi: ./
   name: biostatistics
   version: 0.1.0
-  sha256: 61ebbfad5811194e22273ca77d21c38bfa93db86b6770bdb018dd82bb56693e5
+  sha256: 9b4d15f77c0b42ac0eb3f072b91c070cbab345b602e8ed9f4aae186d4bed7fd5
   requires_python: ==3.12
 - pypi: https://files.pythonhosted.org/packages/ca/9f/f1adeadf3ec4a3bd3d1d9c809bce8526ceb3b571e8dd8356c26de0dc699e/bitarray-3.9.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: bitarray
@@ -5617,6 +5620,18 @@ packages:
   purls: []
   size: 2348171
   timestamp: 1675353652214
+- conda: https://conda.anaconda.org/conda-forge/linux-64/popt-1.19-h3b78370_0.conda
+  sha256: 6fdd61c3aa1780a902f0ded56237b6af131bc4d261a880e822252e20f50b9bdb
+  md5: 8cc2a5b668fd13c4abf4a94a013ebdb6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 177450
+  timestamp: 1765445075774
 - conda: https://conda.anaconda.org/conda-forge/linux-64/prometheus-cpp-1.3.0-ha5d0236_0.conda
   sha256: 013669433eb447548f21c3c6b16b2ed64356f726b5f77c1b39d5ba17a8a4b8bc
   md5: a83f6a2fdc079e643237887a37460668
@@ -9319,6 +9334,24 @@ packages:
   - pandas>=1.3.5,<3.0 ; python_full_version >= '3.10' and extra == 'all'
   - pandas<3.0 ; python_full_version < '3.10' and extra == 'all'
   requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rsync-3.4.4-h5440a77_0.conda
+  sha256: 0f8b7721bd3c3ccbe88c71211f89783396a1333144963f23105242e808ecd8af
+  md5: 1f296293c526b4524c374345cf3358f5
+  depends:
+  - libgcc >=14
+  - __glibc >=2.28,<3.0.a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - libiconv >=1.18,<2.0a0
+  - xxhash >=0.8.3,<0.8.4.0a0
+  - openssl >=3.5.6,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - popt >=1.16,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  size: 376631
+  timestamp: 1780999334789
 - pypi: https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: ruff
   version: 0.16.0
@@ -10448,6 +10481,17 @@ packages:
   version: 3.8.1
   sha256: 82c0cedd280eab2e8291270e6c04894dbc096f8159a39dcf1807429f026ca3cc
   requires_python: '>=3.8'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xxhash-0.8.3-hb47aa4a_0.conda
+  sha256: 08e12f140b1af540a6de03dd49173c0e5ae4ebc563cabdd35ead0679835baf6f
+  md5: 607e13a8caac17f9a664bcab5302ce06
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 108219
+  timestamp: 1746457673761
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.8.3-ha02ee65_0.conda
   sha256: 2553fd3ec0a1020b2ca05ca10b0036a596cb0d4bf3645922fcf69dacce0e6679
   md5: 6a1b6af49a334e4e06b9f103367762bf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,8 @@ duckdb = ">=1.4.1,<2"
 # is set under the `bibtex` plugin in mkdocs.yml.
 pandoc = ">=3.8.2.1,<4"
 bcftools = ">=1.22,<2"
+# Used by the migrate-asset-store task to move asset store subtrees between disks.
+rsync = ">=3.4.4,<4"
 typos = ">=1.41.0,<2"
 r-base = ">=4.0,<4.6"
 bioconductor-celldex = ">=1.16.0,<2"

--- a/tasks.py
+++ b/tasks.py
@@ -8,6 +8,8 @@ Note that when running tasks this way, underscores (_) in task names should be r
 
 import datetime as _dt
 import os
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -490,6 +492,132 @@ def build_docs(c):
     cmd = "mkdocs build --strict"
     print(f"running {cmd}")
     c.run(cmd)
+
+
+### Asset store maintenance
+
+
+# Metadata is deliberately not preserved: some asset stores live on mounts (for example
+# Windows drives mounted in WSL) that reject utime and chmod, which makes a metadata
+# preserving copy fail after the data has already been transferred.  Asset integrity is
+# tracked by the build system's verifying trace, not by filesystem metadata.  --size-only
+# then keeps a re-run cheap despite the missing timestamps.
+_RSYNC_ARGS = (
+    "-r --size-only --no-perms --no-times --no-group --no-owner "
+    "--human-readable --info=progress2"
+)
+
+
+def _dir_size(path: Path) -> str:
+    result = subprocess.run(
+        ["du", "-sh", str(path)], capture_output=True, text=True, check=False
+    )
+    if result.returncode != 0:
+        return "unknown"
+    return result.stdout.split("\t")[0]
+
+
+@task(
+    help={
+        "execute": "Actually move data.  Without this the task only reports what it would do.",
+        "reverse": "Move data back from the remap roots to the default asset root.  Run this BEFORE deleting a rule from the config, since the task only knows about subtrees the config still declares.",
+        "only": "Restrict the run to configured prefixes containing this substring, so a large migration can be staged one subtree at a time without editing the config.",
+    }
+)
+def migrate_asset_store(
+    c, execute: bool = False, reverse: bool = False, only: str | None = None
+):
+    """
+    Reconcile the asset store on disk with the path_remap rules in
+    default_runner_config.yaml.
+
+    Remapping where an asset lives does not invalidate its verifying trace, because traces
+    are content hashes and carry no location.  Changing the config without moving the data
+    does, however, hide the existing assets from the build system, which then rebuilds them
+    at the new location while the old copy keeps occupying the disk.  This task performs
+    that move.
+
+    It is a dry run by default, since a single invocation can move tens of gigabytes.  Pass
+    --execute to do the work, --only to stage a large migration one subtree at a time, or
+    --reverse --execute to bring a subtree back to the default root.
+
+    A subtree that is present under BOTH roots is reported and skipped: the two copies may
+    have diverged, and picking a winner is not something this task should decide.
+    """
+    # Imported here rather than at module scope because importing the default runner takes
+    # ~1.5s and has side effects: it reads default_runner_config.yaml, logs it, and stats
+    # the asset store to warn about unmigrated subtrees.  tasks.py is the entry point for
+    # every repo command, so at module scope that noise and delay would land on unrelated
+    # ones like `invoke format`.
+    from mecfs_bio.analysis.runner.default_runner import DEFAULT_RUNNER
+
+    asset_root = DEFAULT_RUNNER.asset_root
+    rules = DEFAULT_RUNNER.path_remap
+    if not rules:
+        print("No path_remap rules configured; nothing to migrate.")
+        return
+
+    print(f"default asset root: {asset_root}")
+    print(f"mode: {'REVERSE (remap root -> default)' if reverse else 'remap'}")
+    if not execute:
+        print("DRY RUN -- pass --execute to actually move data.\n")
+
+    if only is not None:
+        print(f"restricted to prefixes containing: {only}")
+
+    planned: list[tuple[Path, Path]] = []
+    for rule in rules:
+        for prefix in rule.prefixes:
+            if only is not None and only not in str(prefix):
+                continue
+            default_side = asset_root / prefix
+            remap_side = rule.root / prefix
+            src, dst = (
+                (remap_side, default_side) if reverse else (default_side, remap_side)
+            )
+            if src.exists() and dst.exists():
+                print(
+                    f"  DIVERGED {prefix}: present under both {src} and {dst}.  "
+                    f"Skipping -- resolve by hand."
+                )
+                continue
+            if not src.exists():
+                status = "already in place" if dst.exists() else "no data"
+                print(f"  SKIP     {prefix}: {status}.")
+                continue
+            print(f"  MOVE     {prefix} ({_dir_size(src)}): {src} -> {dst}")
+            planned.append((src, dst))
+
+    if not planned:
+        print("\nNothing to do.")
+        return
+    if not execute:
+        print(f"\n{len(planned)} subtree(s) would be moved.  Re-run with --execute.")
+        return
+
+    for src, dst in planned:
+        print(f"\nmoving {src} -> {dst}")
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        c.run(f'rsync {_RSYNC_ARGS} "{src}/" "{dst}/"', pty=True)
+        # Confirm the copy is complete before deleting anything.  A second pass that
+        # reports no remaining transfers is the check.
+        verify = c.run(
+            f'rsync {_RSYNC_ARGS} --dry-run --itemize-changes "{src}/" "{dst}/"',
+            hide=True,
+        )
+        remaining = [
+            line for line in verify.stdout.splitlines() if line.startswith(("<", ">"))
+        ]
+        if remaining:
+            print(
+                f"REFUSING to delete {src}: {len(remaining)} file(s) still differ after "
+                f"the copy.  First few: {remaining[:5]}"
+            )
+            continue
+        shutil.rmtree(src)
+        print(f"moved and removed source {src}")
+
+    print("\nDone.  Re-run without --execute to confirm the store is consistent.")
 
 
 # initialization

--- a/test_mecfs_bio/unit/build_system/rebuilder/metadata_to_path/test_remapping_meta_to_path.py
+++ b/test_mecfs_bio/unit/build_system/rebuilder/metadata_to_path/test_remapping_meta_to_path.py
@@ -1,0 +1,163 @@
+from pathlib import Path, PurePath
+
+import pytest
+
+from mecfs_bio.build_system.meta.asset_id import AssetId
+from mecfs_bio.build_system.meta.meta import Meta
+from mecfs_bio.build_system.meta.reference_meta.reference_file_meta import (
+    ReferenceFileMeta,
+)
+from mecfs_bio.build_system.meta.simple_directory_meta import SimpleDirectoryMeta
+from mecfs_bio.build_system.meta.simple_file_meta import SimpleFileMeta
+from mecfs_bio.build_system.rebuilder.metadata_to_path.remapping_meta_to_path import (
+    PathRemapRule,
+    RemappingMetaToPath,
+    stale_default_root_dirs,
+)
+from mecfs_bio.build_system.rebuilder.metadata_to_path.simple_meta_to_path import (
+    SimpleMetaToPath,
+    simple_meta_to_relative_path,
+)
+
+DEFAULT_ROOT = Path("/default_root")
+REMAP_ROOT = Path("/remap_root")
+
+DB_SNP_PREFIX = PurePath("reference_data/db_snp_reference_data")
+
+
+def _reference_file_meta(group: str, asset_id: str = "some_file") -> ReferenceFileMeta:
+    return ReferenceFileMeta(
+        group=group,
+        sub_group="some_sub_group",
+        sub_folder=PurePath("some_sub_folder"),
+        extension=".vcf.gz",
+        id=AssetId(asset_id),
+    )
+
+
+ALL_META_KINDS = [
+    SimpleFileMeta(AssetId("a_file")),
+    SimpleDirectoryMeta(AssetId("a_directory")),
+    _reference_file_meta("db_snp_reference_data"),
+    _reference_file_meta("linkage_disequilibrium_scores"),
+]
+
+
+@pytest.mark.parametrize(argnames="meta", argvalues=ALL_META_KINDS)
+def test_no_rules_is_equivalent_to_simple_meta_to_path(meta: Meta) -> None:
+    """
+    Remapping with an empty rule set must not perturb the existing store layout.
+    """
+    remapping = RemappingMetaToPath(default_root=DEFAULT_ROOT, rules=())
+    assert remapping(meta) == SimpleMetaToPath(root=DEFAULT_ROOT)(meta)
+
+
+def test_matched_prefix_is_routed_to_the_rule_root() -> None:
+    meta = _reference_file_meta("db_snp_reference_data")
+    remapping = RemappingMetaToPath(
+        default_root=DEFAULT_ROOT,
+        rules=(PathRemapRule(root=REMAP_ROOT, prefixes=(DB_SNP_PREFIX,)),),
+    )
+    assert remapping(meta) == REMAP_ROOT / simple_meta_to_relative_path(meta)
+
+
+def test_unmatched_prefix_stays_under_the_default_root() -> None:
+    meta = _reference_file_meta("linkage_disequilibrium_scores")
+    remapping = RemappingMetaToPath(
+        default_root=DEFAULT_ROOT,
+        rules=(PathRemapRule(root=REMAP_ROOT, prefixes=(DB_SNP_PREFIX,)),),
+    )
+    assert remapping(meta) == SimpleMetaToPath(root=DEFAULT_ROOT)(meta)
+
+
+def test_prefix_matching_is_component_wise() -> None:
+    """
+    A string prefix match would wrongly capture a sibling whose name merely starts with
+    the prefix, sending it to a different filesystem than intended.
+    """
+    sibling = _reference_file_meta("db_snp_reference_data_extra")
+    remapping = RemappingMetaToPath(
+        default_root=DEFAULT_ROOT,
+        rules=(PathRemapRule(root=REMAP_ROOT, prefixes=(DB_SNP_PREFIX,)),),
+    )
+    assert remapping(sibling) == SimpleMetaToPath(root=DEFAULT_ROOT)(sibling)
+
+
+def test_overlapping_prefixes_across_rules_are_rejected() -> None:
+    with pytest.raises(AssertionError):
+        RemappingMetaToPath(
+            default_root=DEFAULT_ROOT,
+            rules=(
+                PathRemapRule(root=REMAP_ROOT, prefixes=(PurePath("reference_data"),)),
+                PathRemapRule(root=Path("/other_root"), prefixes=(DB_SNP_PREFIX,)),
+            ),
+        )
+
+
+def test_overlapping_prefixes_within_a_rule_are_rejected() -> None:
+    with pytest.raises(AssertionError):
+        RemappingMetaToPath(
+            default_root=DEFAULT_ROOT,
+            rules=(
+                PathRemapRule(
+                    root=REMAP_ROOT,
+                    prefixes=(PurePath("reference_data"), DB_SNP_PREFIX),
+                ),
+            ),
+        )
+
+
+def test_absolute_prefix_is_rejected() -> None:
+    with pytest.raises(AssertionError):
+        PathRemapRule(root=REMAP_ROOT, prefixes=(PurePath("/reference_data"),))
+
+
+def test_empty_prefix_list_is_rejected() -> None:
+    with pytest.raises(AssertionError):
+        PathRemapRule(root=REMAP_ROOT, prefixes=())
+
+
+def test_tuple_from_config_parses_a_realistic_section() -> None:
+    rules = PathRemapRule.tuple_from_config(
+        [
+            {
+                "root": "/mnt/d/asset_store_remote",
+                "prefixes": [
+                    "reference_data/db_snp_reference_data",
+                    "reference_data/genome_annotations",
+                ],
+            }
+        ]
+    )
+    assert rules == (
+        PathRemapRule(
+            root=Path("/mnt/d/asset_store_remote"),
+            prefixes=(
+                PurePath("reference_data/db_snp_reference_data"),
+                PurePath("reference_data/genome_annotations"),
+            ),
+        ),
+    )
+
+
+def test_tuple_from_config_rejects_unknown_keys() -> None:
+    """
+    A typo in a machine-local config should fail loudly rather than silently disabling a
+    rule and sending assets back to the disk the remapping was meant to relieve.
+    """
+    with pytest.raises(AssertionError):
+        PathRemapRule.tuple_from_config(
+            [{"root": "/mnt/d", "prefix": ["reference_data/db_snp_reference_data"]}]
+        )
+
+
+def test_stale_default_root_dirs_reports_unmigrated_subtrees(tmp_path: Path) -> None:
+    rules = (
+        PathRemapRule(
+            root=REMAP_ROOT,
+            prefixes=(DB_SNP_PREFIX, PurePath("reference_data/genome_annotations")),
+        ),
+    )
+    assert stale_default_root_dirs(tmp_path, rules) == []
+    (tmp_path / DB_SNP_PREFIX).mkdir(parents=True)
+    assert stale_default_root_dirs(tmp_path, rules) == [tmp_path / DB_SNP_PREFIX]

--- a/test_mecfs_bio/unit/build_system/runner/test_simple_runner_path_remap.py
+++ b/test_mecfs_bio/unit/build_system/runner/test_simple_runner_path_remap.py
@@ -1,0 +1,163 @@
+"""
+End-to-end coverage of asset-store path remapping through SimpleRunner, which is the
+level at which the feature is actually used.
+"""
+
+from pathlib import Path, PurePath
+from typing import Any, Mapping, Sequence
+
+from structlog.testing import capture_logs
+
+from mecfs_bio.build_system.asset.file_asset import FileAsset
+from mecfs_bio.build_system.meta.asset_id import AssetId
+from mecfs_bio.build_system.meta.simple_file_meta import SimpleFileMeta
+from mecfs_bio.build_system.rebuilder.metadata_to_path.remapping_meta_to_path import (
+    MIGRATE_COMMAND,
+    PathRemapRule,
+)
+from mecfs_bio.build_system.rebuilder.verifying_trace_rebuilder.tracer.imohash import (
+    ImoHasher,
+)
+from mecfs_bio.build_system.runner.simple_runner import SimpleRunner
+from mecfs_bio.build_system.task.counting_task import CountingTask
+from mecfs_bio.build_system.task.external_file_copy_task import ExternalFileCopyTask
+
+# SimpleFileMeta assets live under this subtree of the store.
+OTHER_FILES_PREFIX = PurePath("other_files")
+
+
+def _warning_text(logs: Sequence[Mapping[str, Any]]) -> str:
+    """
+    Join the warning-level events captured from structlog.  structlog is not routed
+    through stdlib logging here, so pytest's caplog fixture sees nothing.
+    """
+    return "\n".join(
+        entry["event"] for entry in logs if entry.get("log_level") == "warning"
+    )
+
+
+def _external_file(tmp_path: Path) -> Path:
+    external_dir = tmp_path / "external"
+    external_dir.mkdir(parents=True, exist_ok=True)
+    external_file = external_dir / "external_file.txt"
+    external_file.write_text("abc123")
+    return external_file
+
+
+def test_remapped_asset_is_written_to_and_retrieved_from_the_remap_root(
+    tmp_path: Path,
+) -> None:
+    """
+    The asset must materialize under the remap root, and a second run must FIND it there
+    rather than rebuild it.  Retrieval is the half that breaks if the mapper and
+    get_asset_if_exists ever disagree about where an asset lives.
+    """
+    asset_root = tmp_path / "asset_store"
+    remap_root = tmp_path / "remote_asset_store"
+    task = CountingTask(
+        ExternalFileCopyTask(
+            meta=SimpleFileMeta(AssetId("remapped_file")),
+            external_path=_external_file(tmp_path),
+        )
+    )
+    runner = SimpleRunner(
+        info_store=tmp_path / "info_store.yaml",
+        asset_root=asset_root,
+        tracer=ImoHasher.with_xxhash_128(),
+        path_remap=(PathRemapRule(root=remap_root, prefixes=(OTHER_FILES_PREFIX,)),),
+    )
+
+    store = runner.run([task])
+
+    asset = store[task.asset_id]
+    assert isinstance(asset, FileAsset)
+    asset_path = asset.path
+    assert asset_path == remap_root / OTHER_FILES_PREFIX / "remapped_file"
+    assert asset_path.read_text() == "abc123"
+    assert not (asset_root / OTHER_FILES_PREFIX).exists()
+    assert task.run_count == 1
+
+    runner.run([task])
+    assert task.run_count == 1
+
+
+def test_run_warns_when_a_remapped_subtree_was_never_migrated(tmp_path: Path) -> None:
+    """
+    Changing the config without moving the data silently costs a full rebuild, so the
+    runner has to say something.  The warning belongs on run() rather than at import of
+    the default runner, so that merely importing the runner stays free of side effects.
+    """
+    asset_root = tmp_path / "asset_store"
+    remap_root = tmp_path / "remote_asset_store"
+    stale_dir = asset_root / OTHER_FILES_PREFIX
+    stale_dir.mkdir(parents=True)
+    task = CountingTask(
+        ExternalFileCopyTask(
+            meta=SimpleFileMeta(AssetId("some_file")),
+            external_path=_external_file(tmp_path),
+        )
+    )
+    runner = SimpleRunner(
+        info_store=tmp_path / "info_store.yaml",
+        asset_root=asset_root,
+        tracer=ImoHasher.with_xxhash_128(),
+        path_remap=(PathRemapRule(root=remap_root, prefixes=(OTHER_FILES_PREFIX,)),),
+    )
+
+    with capture_logs() as logs:
+        runner.run([task])
+
+    warnings = _warning_text(logs)
+    assert str(stale_dir) in warnings
+    assert MIGRATE_COMMAND in warnings
+
+
+def test_run_is_silent_when_nothing_needs_migrating(tmp_path: Path) -> None:
+    task = CountingTask(
+        ExternalFileCopyTask(
+            meta=SimpleFileMeta(AssetId("some_file")),
+            external_path=_external_file(tmp_path),
+        )
+    )
+    runner = SimpleRunner(
+        info_store=tmp_path / "info_store.yaml",
+        asset_root=tmp_path / "asset_store",
+        tracer=ImoHasher.with_xxhash_128(),
+        path_remap=(
+            PathRemapRule(
+                root=tmp_path / "remote_asset_store",
+                prefixes=(PurePath("reference_data"),),
+            ),
+        ),
+    )
+
+    with capture_logs() as logs:
+        runner.run([task])
+
+    assert MIGRATE_COMMAND not in _warning_text(logs)
+
+
+def test_unremapped_asset_stays_under_the_default_root(tmp_path: Path) -> None:
+    asset_root = tmp_path / "asset_store"
+    remap_root = tmp_path / "remote_asset_store"
+    task = CountingTask(
+        ExternalFileCopyTask(
+            meta=SimpleFileMeta(AssetId("local_file")),
+            external_path=_external_file(tmp_path),
+        )
+    )
+    runner = SimpleRunner(
+        info_store=tmp_path / "info_store.yaml",
+        asset_root=asset_root,
+        tracer=ImoHasher.with_xxhash_128(),
+        path_remap=(
+            PathRemapRule(root=remap_root, prefixes=(PurePath("reference_data"),)),
+        ),
+    )
+
+    store = runner.run([task])
+
+    asset = store[task.asset_id]
+    assert isinstance(asset, FileAsset)
+    assert asset.path == asset_root / OTHER_FILES_PREFIX / "local_file"
+    assert not remap_root.exists()


### PR DESCRIPTION
- Problem: asset store can grow large, exceeding laptop storage.  
- Solution: allow selective relocation of parts of asset store to another device.  This can achieved by configuring `default_runner_config.yaml`


Example config:

```
asset_root: assets/base_asset_store
info_store: build_system/verifying_trace_imo_xxh_128_info.yaml

path_remap:
  - root: /mnt/d/asset_store_remote
    prefixes:
      - reference_data/db_snp_reference_data # 85G in 9 files
      - reference_data/genome_annotations # 21G in 2 files
      - reference_data/mixer # 13G in 179 files

```