### PR TITLE
Enable hourly Renovate schedule; never automerge pixi upgrades

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -11,7 +11,8 @@ on:
         description: "Renovate log level (info or debug)"
         type: string
         default: info
-  # schedule: added after dry-run validation.
+  schedule:
+    - cron: "0 * * * *"
 
 concurrency:
   group: renovate

--- a/renovate.json
+++ b/renovate.json
@@ -57,6 +57,11 @@
       ],
       "matchUpdateTypes": ["major","minor", "patch"],
       "automerge": true
+    },
+    {
+      "description": "pixi upgrades change the pixi.lock format (v6 -> v7 at pixi 0.68.0) and must be coordinated with the pixi-version pins in .github/workflows/*.yml and with contributors' local pixi. Never automerge.",
+      "matchPackageNames": ["prefix-dev/pixi"],
+      "automerge": false
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
## My description

Switch to github actions renovate from renovate bot.

## Claude's desccription
Completes the cutover to self-hosted Renovate (follows #985).

The Mend **Renovate** and **Renovate Approve** apps have been uninstalled, and the two PRs
they had opened (#986, #987) are closed — the self-hosted bot filters approvals on
`app/mecfs-bio-renovate` and would never have approved them.

**Dry run passed** ([run 30728924096](https://github.com/trafalmadorian97/mecfs_bioinformatics/actions/runs/30728924096)). The decisive check was a negative — the log does *not*
contain `not permitted in the allowedUnsafeExecutions` — and it positively shows
`"command": "pixi lock --no-progress --color=never --quiet"`. Renovate is regenerating
`pixi.lock` again, which was the whole point.

**Never automerge `prefix-dev/pixi`.** pixi 0.68.0 bumped the `pixi.lock` format from v6 to
v7; its release notes state that "once one developer regenerates pixi.lock in version 7,
every collaborator (and CI) needs a pixi that understands the new format". This repo is
uniformly on 0.67.2 — `pixi.lock` is `version: 6`, and `pixi-version: v0.67.2` is pinned in
`on_pr.yml`, `deploy_docs.yml` and `check_links.yml`. An unattended bump would produce v7
lockfiles that break CI, not just contributors. #986 was exactly that PR.

Expect up to 10 PRs on the first live run (`prHourlyLimit`), after the gap since the hosted
app stopped working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxyJX62EdLsBRjEuF5r4pR