### PR TITLE
Make approve step resilient; cap adjusttext below gwaslab's ceiling

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -78,6 +78,10 @@ jobs:
             exit 0
           fi
 
+          # One un-approvable PR must not prevent the rest from being approved, but a
+          # failure must still surface -- so collect failures and report at the end
+          # rather than aborting on the first (set -e) or swallowing them (|| true).
+          failed=""
           while IFS= read -r pr; do
             [ -n "$pr" ] || continue
             already=$(gh pr view "$pr" --json reviews \
@@ -89,5 +93,13 @@ jobs:
               continue
             fi
             echo "PR #${pr}: approving."
-            gh pr review "$pr" --approve
+            if ! gh pr review "$pr" --approve; then
+              echo "PR #${pr}: approval FAILED."
+              failed="${failed} ${pr}"
+            fi
           done <<< "$pr_numbers"
+
+          if [ -n "$failed" ]; then
+            echo "Failed to approve:${failed}"
+            exit 1
+          fi

--- a/experiments/claude/design_specs/2026-08-01-self-hosted-renovate-design.md
+++ b/experiments/claude/design_specs/2026-08-01-self-hosted-renovate-design.md
@@ -226,9 +226,19 @@ GitHub users and bots are not able to self-approve." It approves PRs from Mend's
 `renovate[bot]`; our PRs will be authored by `app/mecfs-bio-renovate`, a different actor. Left
 unhandled, every PR would stall unapproved against the repo's one-approval requirement.
 
-`GITHUB_TOKEN` approvals do count toward required approvals — "Allow GitHub Actions reviews
-to count towards required approval" is enabled by default — and `github-actions[bot]` is a
-distinct actor from the App, so this is not self-approval.
+`GITHUB_TOKEN` approvals require **two** independent settings, which are easily confused
+(they were conflated in the original version of this spec, and the error only surfaced on the
+first live run):
+
+1. **"Allow GitHub Actions to create and approve pull requests"** (Settings -> Actions ->
+   General -> Workflow permissions) — whether Actions may approve at all. Defaults to
+   **disabled**; without it, `gh pr review --approve` fails with
+   `GitHub Actions is not permitted to approve pull requests`.
+2. **"Allow GitHub Actions reviews to count towards required approval"** — whether such an
+   approval satisfies branch protection. Defaults to enabled.
+
+Both must hold. `github-actions[bot]` is a distinct actor from the App, so this is not
+self-approval.
 
 This means the one-approval gate is satisfied by a bot. That is already true today via
 `renovate-approve`; this changes which bot, not whether the gate is real.

--- a/renovate.json
+++ b/renovate.json
@@ -62,6 +62,11 @@
       "description": "pixi upgrades change the pixi.lock format (v6 -> v7 at pixi 0.68.0) and must be coordinated with the pixi-version pins in .github/workflows/*.yml and with contributors' local pixi. Never automerge.",
       "matchPackageNames": ["prefix-dev/pixi"],
       "automerge": false
+    },
+    {
+      "description": "gwaslab pins adjusttext >=0.7.3,<=0.8, so adjusttext 1.x can never resolve and pixi lock fails. Lift this ceiling only once gwaslab relaxes its pin.",
+      "matchPackageNames": ["adjusttext"],
+      "allowedVersions": "<=0.8"
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION

## Claude description
Follow-up to #988, from the first live run ([30729779702](https://github.com/trafalmadorian97/mecfs_bioinformatics/actions/runs/30729779702)).

**The core fix works** — PRs #992, #993, #994, #995 all carry `pixi.lock` alongside
`pyproject.toml`. Renovate is regenerating lockfiles again.

Two problems that run exposed:

1. **The approve step aborted on first failure.** Under `set -e`, one failed approval killed
   the loop and the remaining PRs were never attempted. Now collects failures and exits
   non-zero at the end, so one un-approvable PR cannot block the rest.

2. **adjusttext can never resolve.** `gwaslab==4.2.1` pins `adjusttext >=0.7.3,<=0.8`, so
   `adjusttext 1.x` fails `pixi lock` every time. Capped at `<=0.8` with the reason recorded
   in the rule's `description`. (The `r-base` 4.6 conflict is left alone deliberately —
   conda-forge simply hasn't rebuilt `r-cpp11` against 4.6 yet, and #989 will self-heal once
   it does.)

**Requires a repo setting change to take effect:** Settings → Actions → General → Workflow
permissions → **Allow GitHub Actions to create and approve pull requests**. Approvals fail
with `GitHub Actions is not permitted to approve pull requests` until that is enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxyJX62EdLsBRjEuF5r4pR