### PR TITLE
Drop the Renovate cache step: it broke every run after the first

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -38,13 +38,12 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v7
 
-      - name: Restore Renovate cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/renovate/cache
-          key: renovate-cache-${{ github.run_id }}
-          restore-keys: renovate-cache-
-
+      # No actions/cache step here, deliberately. Caching /tmp/renovate made every run
+      # after the first fail with `EACCES: permission denied, mkdir /tmp/renovate/repos`:
+      # actions/cache restores the tree owned by `runner`, but the Renovate container runs
+      # as an unprivileged user that then cannot create directories inside it. Runs with a
+      # cache miss succeeded; every run with a cache hit failed. The fix is to drop the
+      # cache, NOT to run the container as root -- it was only a speed optimisation.
       - name: Run Renovate
         uses: renovatebot/github-action@v46.2.0
         with:
@@ -52,7 +51,6 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           renovate-version: 44.5.3
         env:
-          RENOVATE_REPOSITORY_CACHE: enabled
           RENOVATE_DRY_RUN: ${{ inputs.dryRun && 'full' || '' }}
           # Fallback matters: on scheduled runs `inputs` is null, and LOG_LEVEL is read
           # by the logger directly rather than through Renovate's option parsing (which

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -38,12 +38,6 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v7
 
-      # No actions/cache step here, deliberately. Caching /tmp/renovate made every run
-      # after the first fail with `EACCES: permission denied, mkdir /tmp/renovate/repos`:
-      # actions/cache restores the tree owned by `runner`, but the Renovate container runs
-      # as an unprivileged user that then cannot create directories inside it. Runs with a
-      # cache miss succeeded; every run with a cache hit failed. The fix is to drop the
-      # cache, NOT to run the container as root -- it was only a speed optimisation.
       - name: Run Renovate
         uses: renovatebot/github-action@v46.2.0
         with:

--- a/renovate.json
+++ b/renovate.json
@@ -72,7 +72,13 @@
       "description": "setuptools 82 removed pkg_resources, which zepid and testmon still import at import time. See the comment above the setuptools pin in pyproject.toml. Lift this ceiling only once zepid no longer imports pkg_resources.",
       "matchPackageNames": ["setuptools"],
       "allowedVersions": "<82"
-    }
+    },
+
+    {
+    "description": "upload pages v4 introduced a gotcha and potentially breaking change",
+    "matchPackageNames": ["actions/upload-pages-artifact@v3"],
+    "allowedVersions": "<v4"
+  ,}
   ],
   "lockFileMaintenance": {
     "enabled": true,

--- a/renovate.json
+++ b/renovate.json
@@ -67,6 +67,11 @@
       "description": "gwaslab pins adjusttext >=0.7.3,<=0.8, so adjusttext 1.x can never resolve and pixi lock fails. Lift this ceiling only once gwaslab relaxes its pin.",
       "matchPackageNames": ["adjusttext"],
       "allowedVersions": "<=0.8"
+    },
+    {
+      "description": "setuptools 82 removed pkg_resources, which zepid and testmon still import at import time. See the comment above the setuptools pin in pyproject.toml. Lift this ceiling only once zepid no longer imports pkg_resources.",
+      "matchPackageNames": ["setuptools"],
+      "allowedVersions": "<82"
     }
   ],
   "lockFileMaintenance": {

--- a/renovate.json
+++ b/renovate.json
@@ -78,7 +78,7 @@
     "description": "upload pages v4 introduced a gotcha and potentially breaking change",
     "matchPackageNames": ["actions/upload-pages-artifact@v3"],
     "allowedVersions": "<v4"
-  ,}
+    }
   ],
   "lockFileMaintenance": {
     "enabled": true,

--- a/renovate.json
+++ b/renovate.json
@@ -76,7 +76,7 @@
 
     {
     "description": "upload pages v4 introduced a gotcha and potentially breaking change",
-    "matchPackageNames": ["actions/upload-pages-artifact@v3"],
+    "matchPackageNames": ["actions/upload-pages-artifact"],
     "allowedVersions": "<v4"
     }
   ],


### PR DESCRIPTION
Renovate bot runs in unprivileged mode, so cannot access cache. Delete the cache.