### PR TITLE
Use renovate to update pixi package manager in CI

### DIFF
--- a/experiments/claude/design_specs/2026-08-02-renovate-pixi-workflow-version-plan.md
+++ b/experiments/claude/design_specs/2026-08-02-renovate-pixi-workflow-version-plan.md
@@ -1,0 +1,130 @@
+# Renovate pixi workflow-version automation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Have Renovate keep the pixi `pixi-version` pins in `.github/workflows/*.yml` current, atomically with the `constraints.pixi` pin in `renovate.json`, and let pixi bumps automerge.
+
+**Architecture:** Add one regex customManager to `renovate.json` that matches `pixi-version: vX.Y.Z` in every workflow file. Because it emits the same `depName`/`datasource`/`currentValue` as the existing `constraints.pixi` customManager, Renovate groups both edits onto one branch (see spec section 2). Flip the existing `prefix-dev/pixi` packageRule to `automerge: true` and rewrite its now-obsolete description.
+
+**Tech Stack:** Renovate config (JSON), regex customManager, GitHub releases datasource.
+
+**Spec:** `experiments/claude/design_specs/2026-08-02-renovate-pixi-workflow-version.md`
+
+## Global Constraints
+
+- `constraints.pixi` in `renovate.json` MUST stay an EXACT version (`0.67.2` today), never a range. Renovate resolves the lock-generation pixi as `config.constraints?.pixi ?? requires-pixi`; a range would resolve to newest and could emit a lock CI cannot read.
+- Do NOT add `requires-pixi` to `pyproject.toml`. Do NOT add any CI reconciliation check. (Explicitly out of scope per spec.)
+- The `v` prefix in `pixi-version: vX.Y.Z` MUST stay OUTSIDE the regex capture group, so it is preserved on rewrite and the captured value is byte-identical to the bare `constraints.pixi` value.
+- The new customManager must use `datasourceTemplate: github-releases`, `depNameTemplate: prefix-dev/pixi`, `extractVersionTemplate: ^v(?<version>.+)$` — identical to the existing `constraints.pixi` customManager — so both updates share one branch.
+
+---
+
+### Task 1: Add workflow-pixi customManager, enable pixi automerge
+
+**Files:**
+- Modify: `renovate.json` (add one `customManagers` entry; edit the `prefix-dev/pixi` `packageRules` entry)
+
+**Interfaces:**
+- Consumes: the existing `constraints.pixi` customManager (`renovate.json` lines ~20-30) as the pattern to mirror for datasource/depName/extractVersion.
+- Produces: nothing other tasks depend on (terminal task).
+
+- [ ] **Step 1: Verify the regex captures all three pins and preserves `v` on rewrite**
+
+The repo already has a probe script from the design phase. Run it to confirm the capture group and rewrite behavior before editing config:
+
+```bash
+python3 - <<'EOF'
+import re, pathlib, glob
+# Mirror Renovate's matchString; Renovate replaces ONLY the capture group.
+pat = re.compile(r"pixi-version:\s*v(?P<currentValue>\d+\.\d+\.\d+)")
+files = sorted(glob.glob(".github/workflows/*.yml"))
+hits = 0
+for f in files:
+    txt = pathlib.Path(f).read_text()
+    for m in pat.finditer(txt):
+        hits += 1
+        new = txt[:m.start("currentValue")] + "0.99.0" + txt[m.end("currentValue"):]
+        line = new[new.rfind("\n",0,m.start())+1 : new.find("\n", m.start())]
+        assert "v0.99.0" in line, f"v prefix lost in {f}: {line!r}"
+        print(f"{f}: captured={m.group('currentValue')!r} -> {line.strip()}")
+assert hits == 3, f"expected 3 pins, found {hits}"
+print("OK: 3 pins, v preserved on rewrite")
+EOF
+```
+
+Expected: three lines, each rewritten to `pixi-version: v0.99.0`, then `OK: 3 pins, v preserved on rewrite`. If it does not print OK, STOP — the regex or the workflow files changed and the plan needs revisiting.
+
+- [ ] **Step 2: Add the customManager to `renovate.json`**
+
+In the `customManagers` array, add this entry after the existing `renovate.json`-constraints manager (order does not matter to Renovate; keep it adjacent for readability):
+
+```json
+{
+  "customType": "regex",
+  "managerFilePatterns": ["/^\\.github/workflows/.+\\.yml$/"],
+  "matchStrings": ["pixi-version:\\s*v(?<currentValue>\\d+\\.\\d+\\.\\d+)"],
+  "datasourceTemplate": "github-releases",
+  "depNameTemplate": "prefix-dev/pixi",
+  "extractVersionTemplate": "^v(?<version>.+)$"
+}
+```
+
+- [ ] **Step 3: Flip `prefix-dev/pixi` to automerge and rewrite its description**
+
+Find the `packageRules` entry for `prefix-dev/pixi` (currently `"automerge": false` with a description about coordinating workflow pins by hand). Replace the whole entry with:
+
+```json
+{
+  "description": "pixi bumps move the three workflow pixi-version pins and constraints.pixi together on one Renovate branch (same depName+datasource+currentValue). Automerge is on: every step is lock-format safe (newer pixi reads older locks), and a contributor on stale pixi gets pixi's native self-update message. See experiments/claude/design_specs/2026-08-02-renovate-pixi-workflow-version.md.",
+  "matchPackageNames": ["prefix-dev/pixi"],
+  "automerge": true
+}
+```
+
+- [ ] **Step 4: Validate the JSON**
+
+```bash
+python3 -c "import json; json.load(open('renovate.json')); print('renovate.json valid JSON')"
+```
+
+Expected: `renovate.json valid JSON`. (Renovate config is JSON5-tolerant, but keeping it strict-JSON-valid avoids surprises; this file is plain JSON today.)
+
+- [ ] **Step 5: Confirm exactly one `automerge: true` change and the exact-pin constraint survived**
+
+```bash
+grep -n '"constraints"' -A2 renovate.json          # must still show "pixi": "0.67.2" (exact, no range)
+grep -n 'prefix-dev/pixi' renovate.json            # depName present in customManager + packageRule
+grep -c '"github-actions/.\+\.yml"' renovate.json || true
+```
+
+Expected: `constraints.pixi` is still the exact string `0.67.2`; `prefix-dev/pixi` appears in both a customManager (`depNameTemplate`) and the packageRule (`matchPackageNames`). If `constraints.pixi` is anything but an exact version, STOP — the Global Constraints are violated.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add renovate.json experiments/claude/design_specs/2026-08-02-renovate-pixi-workflow-version.md experiments/claude/design_specs/2026-08-02-renovate-pixi-workflow-version-plan.md experiments/claude/pixi_lockfile_compat_matrix.sh experiments/claude/logs/pixi_lockfile_compat_matrix.log
+git commit -m "Renovate: keep workflow pixi-version pins current, automerge pixi
+
+Add a regex customManager that updates pixi-version in all workflow files;
+it shares a branch with the constraints.pixi update (same depName/datasource/
+currentValue), so CI pins and the lock-generation constraint move atomically.
+Flip prefix-dev/pixi to automerge:true.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01CxyJX62EdLsBRjEuF5r4pR"
+```
+
+---
+
+## Rollout verification (post-merge, not a code step)
+
+These confirm the design's two live claims. They cannot run locally — they need the self-hosted Renovate workflow — so they happen after the PR merges to `main`.
+
+1. **One-branch grouping (the ~96% claim from spec §2).** Dispatch the Renovate workflow with `dryRun: true`, `logLevel: debug`. In the log, confirm Renovate plans a SINGLE branch touching both `renovate.json` and the workflow files for `prefix-dev/pixi` — not two `prefix-dev/pixi` branches. Two branches means the grouping assumption broke; investigate before enabling further.
+2. **Automerge path.** The first real pixi bump PR should update all four pins on one branch, pass CI (new pixi vs. existing older-format lock), and automerge. Watch the first one end-to-end.
+
+## Self-Review notes
+
+- **Spec coverage:** §Design 1 (customManager) → Task 1 Step 2. §Design 2 (one-branch, why safe) → verified Step 1 + Rollout 1. §Design 3 (exact constraints.pixi) → Global Constraints + Step 5 guard. §Design 4 (automerge:true + rewritten description) → Step 3. §"What we are NOT doing" → Global Constraints. All covered.
+- **No placeholders:** every step has runnable commands / literal JSON.
+- **Consistency:** the customManager JSON matches the spec verbatim; `depName`/`datasource`/`extractVersion` identical to the existing constraints manager, which is the property that guarantees one branch.

--- a/experiments/claude/design_specs/2026-08-02-renovate-pixi-workflow-version.md
+++ b/experiments/claude/design_specs/2026-08-02-renovate-pixi-workflow-version.md
@@ -1,0 +1,184 @@
+# Renovate: automate the pixi version used by CI workflows
+
+Date: 2026-08-02
+Status: approved, ready for implementation
+
+## Problem
+
+The pixi version is pinned in four places, all edited by hand today:
+
+- `.github/workflows/on_pr.yml` -> `pixi-version: v0.67.2`
+- `.github/workflows/deploy_docs.yml` -> `pixi-version: v0.67.2`
+- `.github/workflows/check_links.yml` -> `pixi-version: v0.67.2`
+- `renovate.json` -> `constraints.pixi: "0.67.2"` (the version Renovate uses to run `pixi lock`)
+
+Renovate already updates `constraints.pixi` via a customManager, but never the three
+workflow pins. So the CI pins drift and are bumped manually. This spec adds Renovate
+coverage for the workflow pins so all four move together, and settles the question of
+whether to also enforce a contributor-local pixi floor.
+
+## Decision: do NOT adopt `requires-pixi`
+
+We considered adding `requires-pixi` to `pyproject.toml` as a contributor-facing version
+floor. We are deliberately NOT doing this. The reasoning rests on measured facts, not
+guesses (experiment: `experiments/claude/pixi_lockfile_compat_matrix.sh`, log in
+`experiments/claude/logs/pixi_lockfile_compat_matrix.log`):
+
+1. **Lockfile compatibility is asymmetric.** A newer pixi reads an older lockfile; an
+   older pixi cannot read a newer one. Measured:
+
+   | pixi | reads v6 lock | reads v7 lock |
+   |------|---------------|---------------|
+   | 0.67.2 (current pin) | yes | no -- hard fail |
+   | 0.75.0 (latest)      | yes (silently rewrites to v7) | yes |
+
+2. **The only thing that has ever broken a contributor is a lock-format bump, and it is
+   rare.** Across the last 100 pixi releases (`v0.23.0` May 2024 -> `v0.75.0` Jul 2026),
+   spanning 54 distinct minor series, the lock format bumped exactly once (v6 -> v7 at
+   0.68.0). pixi has no major versions to hook automation onto -- it has been 0.x for its
+   entire life -- and "move the floor every minor" would force ~54 contributor upgrades to
+   cover one real incompatibility.
+
+3. **pixi's native too-new-lock error is already better than what `requires-pixi` would
+   produce.** The native error names the fix command; the `requires-pixi` guard does not:
+
+   ```
+   x Lock-file version 7 is newer than supported
+   help: Maximum supported version: 6 (pixi v0.67.2)
+         Try running `pixi self-update` to update to the latest version.
+   ```
+
+   vs. the `requires-pixi` guard:
+
+   ```
+   x this project requires pixi '>=0.75.0', but you have pixi 0.67.2
+   help: update pixi to a version that satisfies '>=0.75.0'
+   ```
+
+So adding `requires-pixi` would add machinery, a second place to keep in sync, and a
+worse error message, to guard a failure mode that occurs about once every two years and
+that pixi already reports well. We omit it.
+
+## Design
+
+### 1. New customManager for the workflow pins
+
+Add to `renovate.json` `customManagers`:
+
+```json
+{
+  "customType": "regex",
+  "managerFilePatterns": ["/^\\.github/workflows/.+\\.yml$/"],
+  "matchStrings": ["pixi-version:\\s*v(?<currentValue>\\d+\\.\\d+\\.\\d+)"],
+  "datasourceTemplate": "github-releases",
+  "depNameTemplate": "prefix-dev/pixi",
+  "extractVersionTemplate": "^v(?<version>.+)$"
+}
+```
+
+- A glob (`.+\.yml`) rather than the three literal filenames, so a future workflow that
+  uses `setup-pixi` is covered without anyone remembering to update this.
+- The `v` prefix is left OUTSIDE the capture group, so it is preserved on rewrite
+  (`v0.67.2` -> `v0.75.0`). Verified by simulating the capture-group replacement against
+  all three workflow files.
+
+### 2. Atomic branch property (why this is safe)
+
+The captured `currentValue` from the workflows (`0.67.2`) is byte-identical to the value
+the existing `constraints.pixi` customManager captures from `renovate.json` (`0.67.2`).
+Both customManagers therefore emit the same `depName` (`prefix-dev/pixi`) and the same
+`newValue`, so Renovate groups them onto ONE branch. The CI pins and the
+lock-generation constraint move atomically -- they can never disagree.
+
+**Why one branch, from the Renovate source (confidence ~96%):**
+
+- Renovate creates one branch per unique `branchName`, and the default template is
+  `{{branchPrefix}}{{additionalBranchPrefix}}{{branchTopic}}`, where `branchTopic` is
+  `{{depNameSanitized}}-{{newMajor}}...{{newMinor}}.x...` (from
+  `lib/config/options/index.ts`). The MANAGER NAME appears nowhere in it, and
+  `additionalBranchPrefix` defaults to `''`. So the branch key is a pure function of
+  `depName` plus the resolved version fields.
+- `lib/workers/repository/updates/branchify.ts` buckets updates into a dict keyed by
+  `branchName` (`branchUpgrades[update.branchName] = ...`), and the dedup filters by
+  `packageFile`, `depName`, and `currentValue` -- NOT by manager. Updates from different
+  managers that share a `branchName` land in the same branch.
+- Both managers emit identical `depName` + `datasource` (github-releases) +
+  `currentValue`, so they resolve to identical `newMajor`/`newMinor`/`isPatch`, hence an
+  identical `branchName`. Every input to the key is the same.
+- Strongest evidence: the single workflow customManager already matches `pixi-version` in
+  all THREE workflow files, and those three edits land on one branch. The cross-manager
+  case runs the same code path (the manager-free `branchName` key), so it groups for the
+  same reason.
+
+**Residual risk (~4%), all observable or under our control:** a future `packageRules`
+entry setting `additionalBranchPrefix`/`separateMinorPatch`/`groupName` differently (we
+have none; both managers match the same `prefix-dev/pixi` rule), or the two
+`depNameTemplate`s drifting apart (byte-identical today). The definitive, zero-cost check
+is built into rollout: the first dispatched dry-run lists the branches Renovate WOULD
+create. Two `prefix-dev/pixi` branches instead of one would reveal a split before any real
+bump. Confirm this on the first dry-run.
+
+### 3. Keep `constraints.pixi` exact
+
+`constraints.pixi` in `renovate.json` stays an exact pin, and its customManager stays.
+This is load-bearing: Renovate resolves the pixi tool version as
+`config.constraints?.pixi ?? requires-pixi` (see the pixi manager's `artifacts.ts`). An
+exact pin forces Renovate to run `pixi lock` with exactly the intended version. A range
+here would resolve to the newest satisfying pixi and could silently emit a v7 lock that
+the pinned CI cannot read.
+
+### 4. automerge: true for pixi
+
+Change the existing `prefix-dev/pixi` packageRule from `automerge: false` to
+`automerge: true`, and rewrite its now-obsolete description (which claimed the workflow
+pins must be coordinated by hand -- this spec automates that).
+
+Tradeoff, recorded deliberately: with automerge on, the eventual lock-format transition
+happens with no human watching the merge. This is acceptable because every step of the
+flow below is safe -- the only party ever pushed to upgrade is a contributor on a stale
+pixi, who receives the well-worded native `self-update` message.
+
+## End-to-end flow of a pixi bump
+
+1. Renovate opens ONE PR bumping `constraints.pixi` + all three workflow `pixi-version`
+   pins.
+2. That PR changes no dependencies, so it triggers no lock regeneration. CI runs the NEW
+   pixi against the EXISTING (older-format) lock -- fine, since newer pixi reads older
+   locks. PR automerges.
+3. The next ordinary dependency PR regenerates the lock under the new constraint. If the
+   new pixi bumped the lock format, that PR is the first to carry the new-format lock. CI
+   is already new enough to read it. Green.
+4. A contributor still on old pixi who pulls a new-format lock hits pixi's native error,
+   which names `pixi self-update`. `pixi self-update` is NOT blocked by an unsatisfiable
+   workspace state (verified), so there is no catch-22.
+
+## What we are NOT doing
+
+- Not adding `requires-pixi` to `pyproject.toml`.
+- Not adding a CI check that reconciles lock-format version against a version floor.
+- Not changing how contributors install or upgrade pixi (`pixi self-update` remains the
+  manual, well-messaged path).
+
+## Out of scope / follow-up
+
+- CI currently pins pixi (`v0.67.2`) BELOW what a contributor might upgrade to. Because
+  newer pixi reads older locks but not vice versa, an exact CI pin means any contributor
+  who upgrades and regenerates the lock turns CI red until the pin catches up. This spec
+  keeps CI pinned (so `constraints.pixi` can stay exact and control lock generation), and
+  relies on Renovate to keep that pin current. Letting CI float to newest is a larger
+  change with its own tradeoffs and is not part of this work.
+
+## Verification
+
+- `experiments/claude/pixi_lockfile_compat_matrix.sh` -- reproduces the compatibility
+  matrix, the requires-pixi guard wording, and the self-update-not-blocked result.
+- Regex rewrite simulated against all three workflow files: capture is `0.67.2`, rewrite
+  preserves the `v` prefix.
+- Renovate pixi manager source confirmed: `requires-pixi` is parsed into the schema but
+  never emitted as an updatable dependency (so part B genuinely needs the customManager),
+  and `artifacts.ts` resolves the tool version as
+  `config.constraints?.pixi ?? requires-pixi`.
+- One-branch grouping confirmed against Renovate source: default `branchName`/`branchTopic`
+  in `lib/config/options/index.ts` contain no manager component; `branchify.ts` buckets by
+  `branchName` and dedups by `packageFile`/`depName`/`currentValue`, not by manager. See
+  "Why one branch" above. Verify empirically on the first dispatched dry-run.

--- a/experiments/claude/pixi_lockfile_compat_matrix.sh
+++ b/experiments/claude/pixi_lockfile_compat_matrix.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Measure the pixi lockfile forward/backward compatibility matrix.
+#
+# Motivating question: if we adopt `requires-pixi` as a LOWER BOUND, a contributor
+# bisecting through old commits keeps whatever (newer) pixi they have installed. That
+# is only workable if a newer pixi can consume an older lockfile without rewriting it.
+# Conversely, if someone on an old pixi pulls a branch whose lock was written by a
+# newer pixi, we need to know exactly what they see.
+#
+# pixi 0.68.0 bumped the lock format v6 -> v7, so 0.67.2 (this repo's pin) and 0.75.0
+# (current latest) straddle the boundary and make a clean natural experiment.
+#
+# Run:  bash experiments/claude/pixi_lockfile_compat_matrix.sh 2>&1 \
+#         | tee experiments/claude/logs/pixi_lockfile_compat_matrix.log
+set -uo pipefail
+
+OLD_PIXI="$(command -v pixi)"
+WORK="${TMPDIR:-/tmp}/pixi_compat_$$"
+NEW_VER="0.75.0"
+mkdir -p "$WORK"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "### old pixi: $OLD_PIXI ($($OLD_PIXI --version))"
+
+# --- fetch the new pixi into an isolated dir (never touches ~/.pixi) -----------------
+echo
+echo "### downloading pixi $NEW_VER"
+curl -fsSL -o "$WORK/pixi-new.tar.gz" \
+  "https://github.com/prefix-dev/pixi/releases/download/v${NEW_VER}/pixi-x86_64-unknown-linux-musl.tar.gz"
+mkdir -p "$WORK/newbin"
+tar -xzf "$WORK/pixi-new.tar.gz" -C "$WORK/newbin"
+NEW_PIXI="$WORK/newbin/pixi"
+chmod +x "$NEW_PIXI"
+echo "### new pixi: $($NEW_PIXI --version)"
+
+# A deliberately tiny workspace: we are testing lockfile FORMAT handling, not solving.
+make_ws() {
+  local dir="$1"
+  mkdir -p "$dir"
+  cat >"$dir/pixi.toml" <<'EOF'
+[workspace]
+name = "compat"
+channels = ["conda-forge"]
+platforms = ["linux-64"]
+
+[dependencies]
+xz = "*"
+EOF
+}
+
+lock_version() { grep -m1 '^version:' "$1/pixi.lock" 2>/dev/null || echo "version: <none>"; }
+
+# ------------------------------------------------------------------ case 1: v6 lock
+echo
+echo "======================================================================"
+echo "CASE 1: lock written by OLD pixi (expect v6), then read by NEW pixi"
+echo "======================================================================"
+make_ws "$WORK/c1"
+(cd "$WORK/c1" && "$OLD_PIXI" lock >/dev/null 2>&1)
+echo "--- lock as written by old pixi: $(lock_version "$WORK/c1")"
+cp "$WORK/c1/pixi.lock" "$WORK/c1/pixi.lock.orig"
+
+echo "--- NEW pixi: does 'lock --check' accept the v6 lock as up to date?"
+(cd "$WORK/c1" && "$NEW_PIXI" lock --check 2>&1 | tail -5)
+echo "    exit=$?"
+
+echo "--- NEW pixi: did merely reading it rewrite the file?"
+if cmp -s "$WORK/c1/pixi.lock" "$WORK/c1/pixi.lock.orig"; then
+  echo "    UNCHANGED (good: bisecting would not dirty the working tree)"
+else
+  echo "    REWRITTEN -> now $(lock_version "$WORK/c1")"
+  echo "    (this would show up as a modified pixi.lock during a bisect)"
+fi
+
+echo "--- NEW pixi: does an install --locked against the v6 lock succeed?"
+(cd "$WORK/c1" && "$NEW_PIXI" install --locked 2>&1 | tail -8)
+echo "    exit=$?"
+echo "--- lock after install --locked: $(lock_version "$WORK/c1")"
+if cmp -s "$WORK/c1/pixi.lock" "$WORK/c1/pixi.lock.orig"; then
+  echo "    still UNCHANGED"
+else
+  echo "    CHANGED by install --locked"
+fi
+
+# ------------------------------------------------------------------ case 2: v7 lock
+echo
+echo "======================================================================"
+echo "CASE 2: lock written by NEW pixi (expect v7), then read by OLD pixi"
+echo "======================================================================"
+make_ws "$WORK/c2"
+(cd "$WORK/c2" && "$NEW_PIXI" lock >/dev/null 2>&1)
+echo "--- lock as written by new pixi: $(lock_version "$WORK/c2")"
+
+echo "--- OLD pixi reading a v7 lock (this is the error a stale contributor sees):"
+(cd "$WORK/c2" && "$OLD_PIXI" install --locked 2>&1 | tail -15)
+echo "    exit=$?"
+
+# -------------------------------------------------- case 3: requires-pixi guard text
+echo
+echo "======================================================================"
+echo "CASE 3: requires-pixi lower bound -- exact wording of the guard"
+echo "======================================================================"
+make_ws "$WORK/c3"
+sed -i 's/^platforms = .*/&\nrequires-pixi = ">=0.75.0"/' "$WORK/c3/pixi.toml"
+echo "--- OLD pixi (0.67.2) against requires-pixi = \">=0.75.0\":"
+(cd "$WORK/c3" && "$OLD_PIXI" run echo hi 2>&1 | tail -15)
+echo "    exit=$?"
+
+echo
+echo "--- does the guard fire on a plain 'pixi install' too, or only 'run'?"
+(cd "$WORK/c3" && "$OLD_PIXI" install 2>&1 | tail -6)
+echo "    exit=$?"
+
+echo
+echo "### done"

--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,16 @@
       ],
       "datasourceTemplate": "docker",
       "depNameTemplate": "ghcr.io/renovatebot/renovate"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/.+\\.yml$/"],
+      "matchStrings": [
+        "pixi-version:\\s*v(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "prefix-dev/pixi",
+      "extractVersionTemplate": "^v(?<version>.+)$"
     }
   ],
   "packageRules": [
@@ -63,9 +73,9 @@
       "automerge": true
     },
     {
-      "description": "pixi upgrades change the pixi.lock format (v6 -> v7 at pixi 0.68.0) and must be coordinated with the pixi-version pins in .github/workflows/*.yml and with contributors' local pixi. Never automerge.",
+      "description": "pixi bumps move the three workflow pixi-version pins and constraints.pixi together on one Renovate branch (same depName+datasource+currentValue). Automerge is on: every step is lock-format safe (newer pixi reads older locks), and a contributor on stale pixi gets pixi's native self-update message. See experiments/claude/design_specs/2026-08-02-renovate-pixi-workflow-version.md.",
       "matchPackageNames": ["prefix-dev/pixi"],
-      "automerge": false
+      "automerge": true
     },
     {
       "description": "gwaslab pins adjusttext >=0.7.3,<=0.8, so adjusttext 1.x can never resolve and pixi lock fails. Lift this ceiling only once gwaslab relaxes its pin.",


### PR DESCRIPTION
- Use claude to rewrite renovate config so that it keeps pixi package manager up to date in CI.  This will prevent issues arising from a contributor creating a lockfile with a more recent version that CI pixi can handle.