### PR TITLE
Fix system tests: composite-action pixi pin missed the v7 lock rollout

### DIFF
--- a/.github/actions/run-system-test/action.yml
+++ b/.github/actions/run-system-test/action.yml
@@ -42,7 +42,7 @@ runs:
     - name: Setup Pixi Environment
       uses: prefix-dev/setup-pixi@v0.10.0
       with:
-        pixi-version: v0.67.2
+        pixi-version: v0.75.0
         cache: true
     - name: Snapshot pre-test resources
       shell: bash

--- a/renovate.json
+++ b/renovate.json
@@ -39,7 +39,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^\\.github/workflows/.+\\.yml$/"],
+      "managerFilePatterns": ["/^\\.github/.+\\.ya?ml$/"],
       "matchStrings": [
         "pixi-version:\\s*v(?<currentValue>\\d+\\.\\d+\\.\\d+)"
       ],


### PR DESCRIPTION
- Problem: the version of pixi used in system tests was not being upgraded
- Fix: extend the glob regex to include the system test action