### PR TITLE
Add missing citation to DecodeME documentation page

### DIFF
--- a/docs/Data_Sources/DecodeME.md
+++ b/docs/Data_Sources/DecodeME.md
@@ -1,5 +1,5 @@
 # DecodeME
-DecodeME is a genome-wide association study of people with ME/CFS.  It is the largest ME/CFS study ever performed.  It is lead by [Professor Chris Ponting](https://scholar.google.ca/citations?user=cwT02HYAAAAJ&hl=en).
+DecodeME[@genetics2025initial] is a genome-wide association study of people with ME/CFS.  It is the largest ME/CFS study ever performed.  It is lead by [Professor Chris Ponting](https://scholar.google.ca/citations?user=cwT02HYAAAAJ&hl=en).
 
 ## External Links
 - [Link to study home page](https://institute-genetics-cancer.ed.ac.uk/decodeme)


### PR DESCRIPTION
I realized the DecodeME documentation page did not actually cite the DecodeME preprint.  This PR fixes this.