### PR TITLE
Drop variants with degenerate Z before cross-trait LDSC

### DIFF
--- a/experiments/claude/fibro_ct_ldsc_fix_verification.py
+++ b/experiments/claude/fibro_ct_ldsc_fix_verification.py
@@ -1,0 +1,119 @@
+"""
+Verify the degenerate-Z fix on the real assets, driving the actual task code path
+(load_and_preprocess_sumstats + get_compatible_snps_polars + estimate_rg_by_ldsc)
+rather than a hand-rolled imitation.
+
+Reproduces the Fibromyalgia x Schizophrenia pair from CT_LDSC_INITIAL_ASSET_GENERATOR,
+including the schizophrenia total-N pipe that the production config applies.
+
+Run:
+    pixi r python experiments/claude/fibro_ct_ldsc_fix_verification.py \
+        2>&1 | tee experiments/claude/logs/fibro_ct_ldsc_fix_verification.log
+"""
+
+from pathlib import Path
+
+from mecfs_bio.build_system.asset.base_asset import Asset
+from mecfs_bio.build_system.asset.file_asset import FileAsset
+from mecfs_bio.build_system.meta.asset_id import AssetId
+from mecfs_bio.build_system.meta.gwaslab_meta.gwaslab_sumstats_meta import (
+    GWASLabSumStatsMeta,
+)
+from mecfs_bio.build_system.task.fake_task import FakeTask
+from mecfs_bio.build_system.task.gwaslab.gwaslab_genetic_corr_by_ct_ldsc_task import (
+    BinaryPhenotypeSampleInfo,
+    FilterSettings,
+    SumstatsSource,
+    get_compatible_snps_polars,
+    get_prev_options,
+    load_and_preprocess_sumstats,
+)
+from mecfs_bio.build_system.task.pipes.identity_pipe import IdentityPipe
+from mecfs_bio.build_system.task.pipes.set_col_pipe import SetColToConstantPipe
+from mecfs_bio.constants.gwaslab_constants import (
+    GWASLAB_RSID_COL,
+    GWASLAB_SAMPLE_SIZE_COLUMN,
+)
+
+ASSET_STORE = Path("assets/base_asset_store")
+FIBRO_PICKLE = (
+    ASSET_STORE
+    / "gwas/fibromyalgia/kerrebijn_et_al/gwaslab_sumstats/kerrebijin_fibro_sumstats_37.pickle"
+)
+SCZ_PICKLE = (
+    ASSET_STORE
+    / "gwas/schizophrenia/pgc_2022/gwaslab_sumstats/pgc_2022_sch_sumstats_37.pickle"
+)
+LD_DIR = (
+    ASSET_STORE
+    / "reference_data/linkage_disequilibrium_scores/thousand_genomes_phase_3_v1/extracted"
+    / "thousand_genomes_phase_3_v1_eur_ld_scores_extracted"
+)
+
+
+def make_source(alias: str, pickle_path: Path, sample_info, pipe) -> tuple:
+    asset_id = AssetId(f"{alias.lower()}_sumstats")
+    task = FakeTask(
+        meta=GWASLabSumStatsMeta(id=asset_id, trait=alias.lower(), project="verify")
+    )
+    source = SumstatsSource(
+        task=task, alias=alias, sample_info=sample_info, pipe=pipe
+    )
+
+    def fetch(requested: AssetId) -> Asset:
+        assert requested == asset_id
+        return FileAsset(pickle_path)
+
+    return source, fetch
+
+
+def main() -> None:
+    fibro_source, fibro_fetch = make_source(
+        "Fibromyalgia",
+        FIBRO_PICKLE,
+        BinaryPhenotypeSampleInfo(
+            sample_prevalence=0.5, estimated_population_prevalence=0.027
+        ),
+        IdentityPipe(),
+    )
+    scz_source, scz_fetch = make_source(
+        "Schizophrenia",
+        SCZ_PICKLE,
+        BinaryPhenotypeSampleInfo(
+            sample_prevalence=0.408, estimated_population_prevalence=0.01
+        ),
+        SetColToConstantPipe(GWASLAB_SAMPLE_SIZE_COLUMN, constant=130644),
+    )
+
+    settings = FilterSettings()
+    fibro, fibro_name, fibro_info = load_and_preprocess_sumstats(
+        source=fibro_source, fetch=fibro_fetch, settings=settings, build="19"
+    )
+    scz, scz_name, scz_info = load_and_preprocess_sumstats(
+        source=scz_source, fetch=scz_fetch, settings=settings, build="19"
+    )
+
+    print(f"\nfibro rows reaching LDSC: {len(fibro.data)}")
+    print(f"fibro zero-SE remaining:  {int((fibro.data['SE'] == 0).sum())}")
+
+    compatible = get_compatible_snps_polars(fibro.data, scz.data)
+    scz.data = scz.data.loc[
+        scz.data[GWASLAB_RSID_COL].isin(compatible[GWASLAB_RSID_COL])
+    ]
+
+    options = get_prev_options(trait_1_prev=fibro_info, trait_2_prev=scz_info)
+    fibro.estimate_rg_by_ldsc(
+        other_traits=[scz],
+        rg=f"{fibro_name},{scz_name}",
+        ref_ld_chr=str(LD_DIR) + "/LDscore.@",
+        w_ld_chr=str(LD_DIR) + "/LDscore.@",
+        build="19",
+        **options,
+    )
+
+    print("\n===== RESULT =====")
+    print(fibro.ldsc_rg.to_string())
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/claude/fibro_ct_ldsc_nan_probe.py
+++ b/experiments/claude/fibro_ct_ldsc_nan_probe.py
@@ -1,0 +1,106 @@
+"""
+Probe the Kerrebijn fibromyalgia sumstats for the numerical pathology that makes
+cross-trait LDSC fail with:
+
+    ** On entry to DLASCL parameter number 4 had an illegal value
+    numpy.linalg.LinAlgError: SVD did not converge in Linear Least Squares
+
+That LAPACK message is emitted when the design matrix handed to lstsq contains
+NaN/Inf, so this script looks for non-finite (or degenerate) values in the
+columns that feed the regression: BETA, SE, N and the derived Z = BETA/SE.
+
+It applies the same filtering the CT-LDSC task applies (indels, palindromes,
+HLA, hapmap3, duplicate rsIDs) so the numbers describe the data that actually
+reaches LDSC.
+
+Run:
+    pixi r python experiments/claude/fibro_ct_ldsc_nan_probe.py \
+        2>&1 | tee experiments/claude/logs/fibro_ct_ldsc_nan_probe.log
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from mecfs_bio.build_system.task.gwaslab.gwaslab_genetic_corr_by_ct_ldsc_task import (
+    FilterSettings,
+    filter_sumstats,
+)
+
+FIBRO_PICKLE = Path(
+    "assets/base_asset_store/gwas/fibromyalgia/kerrebijn_et_al/gwaslab_sumstats/kerrebijin_fibro_sumstats_37.pickle"
+)
+SCZ_PICKLE = Path(
+    "assets/base_asset_store/gwas/schizophrenia/pgc_2022/gwaslab_sumstats/pgc_2022_sch_sumstats_37.pickle"
+)
+
+
+def describe(df: pd.DataFrame, label: str) -> None:
+    print(f"\n===== {label} =====")
+    print(f"rows: {len(df)}")
+    print(f"columns: {list(df.columns)}")
+
+    for col in ["BETA", "SE", "N", "EAF", "P"]:
+        if col not in df.columns:
+            print(f"  {col}: ABSENT")
+            continue
+        s = pd.to_numeric(df[col], errors="coerce")
+        n_null = int(df[col].isna().sum())
+        n_nan = int(np.isnan(s.to_numpy(dtype="float64")).sum())
+        n_inf = int(np.isinf(s.to_numpy(dtype="float64")).sum())
+        n_zero = int((s == 0).sum())
+        n_neg = int((s < 0).sum())
+        print(
+            f"  {col}: dtype={df[col].dtype} null={n_null} nan={n_nan} inf={n_inf} "
+            f"zero={n_zero} negative={n_neg} min={s.min()} max={s.max()}"
+        )
+
+    if "BETA" in df.columns and "SE" in df.columns:
+        beta = pd.to_numeric(df["BETA"], errors="coerce").to_numpy(dtype="float64")
+        se = pd.to_numeric(df["SE"], errors="coerce").to_numpy(dtype="float64")
+        with np.errstate(divide="ignore", invalid="ignore"):
+            z = beta / se
+        n_nan = int(np.isnan(z).sum())
+        n_inf = int(np.isinf(z).sum())
+        print(
+            f"  Z=BETA/SE: nan={n_nan} inf={n_inf} "
+            f"finite_min={np.nanmin(z[np.isfinite(z)]) if np.isfinite(z).any() else 'NA'} "
+            f"finite_max={np.nanmax(z[np.isfinite(z)]) if np.isfinite(z).any() else 'NA'}"
+        )
+        bad = ~np.isfinite(z)
+        if bad.any():
+            print(f"\n  --- first 10 rows with non-finite Z ({int(bad.sum())} total) ---")
+            cols = [
+                c
+                for c in ["SNP", "rsID", "CHR", "POS", "EA", "NEA", "BETA", "SE", "P", "N", "EAF"]
+                if c in df.columns
+            ]
+            print(df.loc[bad, cols].head(10).to_string())
+
+        # chi2 = z^2 is what LDSC regresses; report the extremes
+        chi2 = z[np.isfinite(z)] ** 2
+        if chi2.size:
+            print(
+                f"  chi2: mean={chi2.mean():.4f} max={chi2.max():.4f} "
+                f"n_over_80={int((chi2 > 80).sum())}"
+            )
+
+    if "N" in df.columns:
+        n = pd.to_numeric(df["N"], errors="coerce")
+        print(f"  N quantiles: {n.quantile([0, 0.001, 0.5, 0.999, 1.0]).to_dict()}")
+
+
+def main() -> None:
+    import gwaslab
+
+    for label, path in [("FIBROMYALGIA", FIBRO_PICKLE), ("SCHIZOPHRENIA", SCZ_PICKLE)]:
+        sumstats = gwaslab.load_pickle(str(path))
+        describe(sumstats.data, f"{label} raw (as stored)")
+        sumstats.infer_build()
+        filter_sumstats(sumstats, FilterSettings(), build="19")
+        describe(sumstats.data, f"{label} after CT-LDSC filtering")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/claude/fibro_ct_ldsc_zero_se_repro.py
+++ b/experiments/claude/fibro_ct_ldsc_zero_se_repro.py
@@ -1,0 +1,90 @@
+"""
+Confirm that the zero-SE variants in the Kerrebijn fibromyalgia sumstats are what
+break cross-trait LDSC, by running the Fibromyalgia x Schizophrenia rg twice:
+
+  run A: data exactly as the CT-LDSC task feeds it today  -> expected to fail
+  run B: same data with SE == 0 variants dropped          -> expected to succeed
+
+gwaslab catches the LinAlgError internally and then crashes in its own error
+handler (traceback.format_exc(ex) passes the exception as `limit`), so run A
+surfaces as a TypeError rather than the LinAlgError itself.
+
+Run:
+    pixi r python experiments/claude/fibro_ct_ldsc_zero_se_repro.py \
+        2>&1 | tee experiments/claude/logs/fibro_ct_ldsc_zero_se_repro.log
+"""
+
+import copy
+from pathlib import Path
+
+import gwaslab
+
+from mecfs_bio.build_system.task.gwaslab.gwaslab_genetic_corr_by_ct_ldsc_task import (
+    FilterSettings,
+    filter_sumstats,
+    get_compatible_snps_polars,
+)
+from mecfs_bio.constants.gwaslab_constants import GWASLAB_RSID_COL
+
+ASSET_STORE = Path("assets/base_asset_store")
+FIBRO_PICKLE = (
+    ASSET_STORE
+    / "gwas/fibromyalgia/kerrebijn_et_al/gwaslab_sumstats/kerrebijin_fibro_sumstats_37.pickle"
+)
+SCZ_PICKLE = (
+    ASSET_STORE
+    / "gwas/schizophrenia/pgc_2022/gwaslab_sumstats/pgc_2022_sch_sumstats_37.pickle"
+)
+LD_DIR = (
+    ASSET_STORE
+    / "reference_data/linkage_disequilibrium_scores/thousand_genomes_phase_3_v1/extracted"
+    / "thousand_genomes_phase_3_v1_eur_ld_scores_extracted"
+)
+
+RG_KWARGS = dict(
+    ref_ld_chr=str(LD_DIR) + "/LDscore.@",
+    w_ld_chr=str(LD_DIR) + "/LDscore.@",
+    build="19",
+    samp_prev="0.5,0.408",
+    pop_prev="0.027,0.01",
+)
+
+
+def load_filtered(path: Path) -> gwaslab.Sumstats:
+    sumstats = gwaslab.load_pickle(str(path))
+    sumstats.infer_build()
+    filter_sumstats(sumstats, FilterSettings(), build="19")
+    return sumstats
+
+
+def run_rg(fibro: gwaslab.Sumstats, scz: gwaslab.Sumstats, label: str) -> None:
+    print(f"\n############ {label} ############")
+    print(f"fibro rows={len(fibro.data)}  zero_SE={int((fibro.data['SE'] == 0).sum())}")
+
+    compatible = get_compatible_snps_polars(fibro.data, scz.data)
+    scz = copy.deepcopy(scz)
+    scz.data = scz.data.loc[
+        scz.data[GWASLAB_RSID_COL].isin(compatible[GWASLAB_RSID_COL])
+    ]
+
+    try:
+        fibro.estimate_rg_by_ldsc(other_traits=[scz], rg="Fibromyalgia,Schizophrenia", **RG_KWARGS)
+        print(f"RESULT [{label}]: SUCCESS")
+        print(fibro.ldsc_rg.to_string())
+    except Exception as exc:  # noqa: BLE001 - we are characterising the failure
+        print(f"RESULT [{label}]: FAILED with {type(exc).__name__}: {exc}")
+
+
+def main() -> None:
+    fibro = load_filtered(FIBRO_PICKLE)
+    scz = load_filtered(SCZ_PICKLE)
+
+    run_rg(copy.deepcopy(fibro), scz, "A: as-is (SE == 0 kept)")
+
+    fibro_clean = copy.deepcopy(fibro)
+    fibro_clean.data = fibro_clean.data.loc[fibro_clean.data["SE"] > 0]
+    run_rg(fibro_clean, scz, "B: SE == 0 dropped")
+
+
+if __name__ == "__main__":
+    main()

--- a/mecfs_bio/build_system/task/gwaslab/gwaslab_genetic_corr_by_ct_ldsc_task.py
+++ b/mecfs_bio/build_system/task/gwaslab/gwaslab_genetic_corr_by_ct_ldsc_task.py
@@ -41,6 +41,9 @@ from mecfs_bio.build_system.meta.read_spec.read_sumstats import read_sumstats
 from mecfs_bio.build_system.meta.result_table_meta import ResultTableMeta
 from mecfs_bio.build_system.rebuilder.fetch.base_fetch import Fetch
 from mecfs_bio.build_system.task.base_task import Task
+from mecfs_bio.build_system.task.gwaslab.ldsc_degenerate_z import (
+    drop_variants_with_degenerate_z,
+)
 from mecfs_bio.build_system.task.harmonize_gwas_with_reference_table_via_rsid import (
     complement_reverse_expr,
     match_flipped_reference_expr,
@@ -308,6 +311,7 @@ def load_and_preprocess_sumstats(
     assert sumstats.build == build
     assert GWASLAB_RSID_COL in sumstats.data.columns
     sumstats.data = source.pipe.process_pandas(sumstats.data)
+    sumstats.data = drop_variants_with_degenerate_z(sumstats.data)
     filter_sumstats(sumstats, settings, build=build)
     _add_N_column_if_missing(sumstats, source=source)
     return sumstats, name, source.sample_info

--- a/mecfs_bio/build_system/task/gwaslab/gwaslab_snp_heritability_by_ldsc_task.py
+++ b/mecfs_bio/build_system/task/gwaslab/gwaslab_snp_heritability_by_ldsc_task.py
@@ -16,7 +16,6 @@ Chapter authors are S. Burgess, C.N. Foley and V. Zuber
 
 from pathlib import Path, PurePath
 
-import numpy as np
 import pandas as pd
 import structlog
 from attrs import frozen
@@ -41,15 +40,15 @@ from mecfs_bio.build_system.task.gwaslab.gwaslab_genetic_corr_by_ct_ldsc_task im
     PhenotypeInfo,
     QuantPhenotype,
 )
+from mecfs_bio.build_system.task.gwaslab.ldsc_degenerate_z import (
+    drop_variants_with_degenerate_z,
+)
 from mecfs_bio.build_system.task.pipes.data_processing_pipe import DataProcessingPipe
 from mecfs_bio.build_system.wf.base_wf import WF
 from mecfs_bio.constants.genomic_coordinate_constants import GenomeBuild
 from mecfs_bio.constants.gwaslab_constants import (
-    GWASLAB_BETA_COL,
     GWASLAB_SAMPLE_SIZE_COLUMN,
-    GWASLAB_SE_COL,
 )
-from mecfs_bio.constants.ldsc_constants import LDSC_Z_COL
 from mecfs_bio.util.type_related.unwrap import unwrap
 
 logger = structlog.get_logger()
@@ -81,7 +80,7 @@ class SNPHeritabilityByLDSCTask(Task):
         sumstats_asset = fetch(self._source_sumstats_id)
         sumstats = read_sumstats(sumstats_asset)
         sumstats.data = self.pipe.process_pandas(sumstats.data)
-        sumstats.data = _drop_variants_with_degenerate_z(sumstats.data)
+        sumstats.data = drop_variants_with_degenerate_z(sumstats.data)
         ref_id = self._ld_ref_id()
         ref_asset = fetch(ref_id)
         assert isinstance(ref_asset, DirectoryAsset)
@@ -142,43 +141,6 @@ class SNPHeritabilityByLDSCTask(Task):
             pipe=pipe,
             build=build,
         )
-
-
-def _drop_variants_with_degenerate_z(data: pd.DataFrame) -> pd.DataFrame:
-    """Drop variants whose LDSC Z score would be non-finite.
-
-    gwaslab builds the LDSC Z score as BETA / SE (or uses an existing Z column). A
-    variant with SE == 0 therefore yields an infinite Z (or NaN, when BETA is also 0,
-    as happens when a source reports an odds ratio rounded to 1.00). deCODE summary
-    statistics contain many such variants: odds ratios rounded to 1.00 give BETA == 0
-    and SE == 0, and underflowed p-values give SE == 0 with a non-zero BETA. A
-    non-finite Z makes the single-trait two-step estimator's IRWLS reweighting produce
-    a non-finite design matrix, which aborts the underlying SVD.
-
-    LDSC's own munge step drops these variants; single-trait estimate_h2_by_ldsc does
-    not (unlike the stratified path, which caps chi-square unconditionally), so we drop
-    them here rather than at the call site, since the requirement is intrinsic to this
-    regression. Variants are matched to gwaslab's Z-resolution order: prefer an existing
-    Z column, otherwise derive the finiteness requirement from BETA and SE.
-    """
-    if LDSC_Z_COL in data.columns:
-        keep = np.isfinite(data[LDSC_Z_COL])
-    elif GWASLAB_BETA_COL in data.columns and GWASLAB_SE_COL in data.columns:
-        keep = (
-            np.isfinite(data[GWASLAB_BETA_COL])
-            & np.isfinite(data[GWASLAB_SE_COL])
-            & (data[GWASLAB_SE_COL] > 0)
-        )
-    else:
-        return data
-    n_dropped = int((~keep).sum())
-    if n_dropped:
-        logger.info(
-            "Dropped variants with degenerate (non-finite) LDSC Z score",
-            n_dropped=n_dropped,
-            n_remaining=int(keep.sum()),
-        )
-    return data.loc[keep].copy()
 
 
 def _get_prev_params(phenotype_info: PhenotypeInfo) -> dict:

--- a/mecfs_bio/build_system/task/gwaslab/ldsc_degenerate_z.py
+++ b/mecfs_bio/build_system/task/gwaslab/ldsc_degenerate_z.py
@@ -1,0 +1,59 @@
+"""
+Shared input guard for the LD score regression tasks.
+
+Both the single-trait heritability regression and the cross-trait genetic
+correlation regression feed Z scores to the same underlying LDSC estimator, and
+both abort on a non-finite Z, so the guard lives here rather than in either task.
+"""
+
+import numpy as np
+import pandas as pd
+import structlog
+
+from mecfs_bio.constants.gwaslab_constants import (
+    GWASLAB_BETA_COL,
+    GWASLAB_SE_COL,
+)
+from mecfs_bio.constants.ldsc_constants import LDSC_Z_COL
+
+logger = structlog.get_logger()
+
+
+def drop_variants_with_degenerate_z(data: pd.DataFrame) -> pd.DataFrame:
+    """Drop variants whose LDSC Z score would be non-finite.
+
+    gwaslab builds the LDSC Z score as BETA / SE (or uses an existing Z column). A
+    variant with SE == 0 therefore yields an infinite Z (or NaN, when BETA is also 0,
+    as happens when a source reports an odds ratio rounded to 1.00). deCODE summary
+    statistics contain many such variants: odds ratios rounded to 1.00 give BETA == 0
+    and SE == 0, and underflowed p-values give SE == 0 with a non-zero BETA. The
+    harmonised GWAS Catalog release of the Kerrebijn fibromyalgia GWAS does the same,
+    reporting BETA as the smallest normal double alongside SE == 0. A non-finite Z
+    makes the IRWLS reweighting produce a non-finite design matrix, which aborts the
+    underlying SVD.
+
+    LDSC's own munge step drops these variants; neither estimate_h2_by_ldsc nor
+    estimate_rg_by_ldsc does (unlike the stratified path, which caps chi-square
+    unconditionally), so we drop them here rather than at the call site, since the
+    requirement is intrinsic to these regressions. Variants are matched to gwaslab's
+    Z-resolution order: prefer an existing Z column, otherwise derive the finiteness
+    requirement from BETA and SE.
+    """
+    if LDSC_Z_COL in data.columns:
+        keep = np.isfinite(data[LDSC_Z_COL])
+    elif GWASLAB_BETA_COL in data.columns and GWASLAB_SE_COL in data.columns:
+        keep = (
+            np.isfinite(data[GWASLAB_BETA_COL])
+            & np.isfinite(data[GWASLAB_SE_COL])
+            & (data[GWASLAB_SE_COL] > 0)
+        )
+    else:
+        return data
+    n_dropped = int((~keep).sum())
+    if n_dropped:
+        logger.info(
+            "Dropped variants with degenerate (non-finite) LDSC Z score",
+            n_dropped=n_dropped,
+            n_remaining=int(keep.sum()),
+        )
+    return data.loc[keep].copy()

--- a/test_mecfs_bio/unit/build_system/task/gwaslab/test_gwaslab_genetic_corr_by_ct_ldsc_task.py
+++ b/test_mecfs_bio/unit/build_system/task/gwaslab/test_gwaslab_genetic_corr_by_ct_ldsc_task.py
@@ -81,6 +81,7 @@ def _make_sumstats(
     eas: list[str],
     neas: list[str],
     study: str = "trait1",
+    ses: list[float] | None = None,
 ) -> gl.Sumstats:
     n = len(rsids)
     df = pd.DataFrame(
@@ -91,7 +92,7 @@ def _make_sumstats(
             "EA": eas,
             "NEA": neas,
             "BETA": [0.01] * n,
-            "SE": [0.05] * n,
+            "SE": [0.05] * n if ses is None else ses,
             "P": [0.5] * n,
             "N": [10000] * n,
         }
@@ -217,3 +218,46 @@ def test_load_and_preprocess_sumstats(tmp_path: Path):
     )
 
     assert set(out_sumstats.data["rsID"]) == {s.rsid for s in real}
+
+
+def test_load_and_preprocess_sumstats_drops_degenerate_z(tmp_path: Path):
+    """Variants with SE == 0 give an infinite LDSC Z (BETA/SE) and abort the SVD
+    inside the cross-trait regression, so they must not reach LDSC.
+
+    Harmonised GWAS Catalog files do contain such variants: the Kerrebijn
+    fibromyalgia sumstats report BETA as the smallest normal double with SE == 0.
+    """
+    snps = _hapmap3_snps(4)
+    degenerate = {snps[1].rsid, snps[2].rsid}
+    sumstats = _make_sumstats(
+        rsids=[s.rsid for s in snps],
+        chroms=[s.chrom for s in snps],
+        positions=[s.pos for s in snps],
+        eas=[s.a1 for s in snps],
+        neas=[s.a2 for s in snps],
+        study="trait_a",
+        ses=[0.05, 0.0, 0.0, 0.05],
+    )
+
+    pickle_path = tmp_path / "sumstats.pickle"
+    gl.dump_pickle(sumstats, path=str(pickle_path))
+
+    source_id = AssetId("trait_a_sumstats")
+    fake_task = FakeTask(
+        meta=GWASLabSumStatsMeta(
+            id=source_id, trait="dummy_trait", project="dummy_project"
+        )
+    )
+    source = SumstatsSource(
+        task=fake_task, alias="trait_a", sample_info=QuantPhenotype()
+    )
+
+    def fetch(asset_id: AssetId) -> Asset:
+        assert asset_id == source_id
+        return FileAsset(pickle_path)
+
+    out_sumstats, _, _ = load_and_preprocess_sumstats(
+        source=source, fetch=fetch, settings=FilterSettings(), build="38"
+    )
+
+    assert set(out_sumstats.data["rsID"]) == {s.rsid for s in snps} - degenerate

--- a/test_mecfs_bio/unit/build_system/task/gwaslab/test_gwaslab_snp_heritability_by_ldsc_task.py
+++ b/test_mecfs_bio/unit/build_system/task/gwaslab/test_gwaslab_snp_heritability_by_ldsc_task.py
@@ -1,8 +1,8 @@
 import numpy as np
 import pandas as pd
 
-from mecfs_bio.build_system.task.gwaslab.gwaslab_snp_heritability_by_ldsc_task import (
-    _drop_variants_with_degenerate_z,
+from mecfs_bio.build_system.task.gwaslab.ldsc_degenerate_z import (
+    drop_variants_with_degenerate_z,
 )
 from mecfs_bio.constants.gwaslab_constants import (
     GWASLAB_BETA_COL,
@@ -24,7 +24,7 @@ def test_drops_zero_se_variants():
             GWASLAB_SE_COL: [0.05, 0.0, 0.0, 0.04],
         }
     )
-    result = _drop_variants_with_degenerate_z(data)
+    result = drop_variants_with_degenerate_z(data)
     assert result[_ID_COL].tolist() == ["a", "d"]
 
 
@@ -36,7 +36,7 @@ def test_keeps_all_finite_se_variants():
             GWASLAB_SE_COL: [0.05, 0.03],
         }
     )
-    result = _drop_variants_with_degenerate_z(data)
+    result = drop_variants_with_degenerate_z(data)
     assert result[_ID_COL].tolist() == ["a", "b"]
 
 
@@ -50,11 +50,11 @@ def test_prefers_existing_z_column():
             GWASLAB_SE_COL: [0.05, 0.05, 0.05],
         }
     )
-    result = _drop_variants_with_degenerate_z(data)
+    result = drop_variants_with_degenerate_z(data)
     assert result[_ID_COL].tolist() == ["a"]
 
 
 def test_noop_without_z_or_beta_se_columns():
     data = pd.DataFrame({_ID_COL: ["a", "b"], GWASLAB_P_COL: [0.1, 0.2]})
-    result = _drop_variants_with_degenerate_z(data)
+    result = drop_variants_with_degenerate_z(data)
     assert result[_ID_COL].tolist() == ["a", "b"]


### PR DESCRIPTION
- Noticed that my CT-LDSC task was retaining variants with standard error=0, which have infinite z score.  Thus causes CT-LDSC to fail
- Fix with Claude code